### PR TITLE
Fix locale encoding when `C.UTF-8` is not available

### DIFF
--- a/nvitop/cli.py
+++ b/nvitop/cli.py
@@ -5,12 +5,11 @@
 
 import argparse
 import curses
-import locale
 import os
 import sys
 
 from nvitop.core import nvml, HostProcess, boolify
-from nvitop.gui import Top, Device, libcurses, colored, set_color, USERNAME
+from nvitop.gui import Top, Device, libcurses, setlocale_utf8, colored, set_color, USERNAME
 from nvitop.version import __version__
 
 
@@ -39,7 +38,7 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
 
     coloring = parser.add_argument_group('coloring')
     coloring.add_argument('--force-color', dest='force_color', action='store_true',
-                        help='Force colorize even when `stdout` is not a TTY terminal.')
+                          help='Force colorize even when `stdout` is not a TTY terminal.')
     coloring.add_argument('--light', action='store_true',
                           help='Tweak visual results for light theme terminals in monitor mode.\n'
                                'Set variable `NVITOP_MONITOR_THEME="light"` on light terminals for convenience.')
@@ -101,17 +100,6 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
 
 
 def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
-    try:
-        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
-    except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, 'C')
-        except locale.Error:
-            try:
-                locale.setlocale(locale.LC_ALL, '')
-            except locale.Error:
-                pass
-
     args = parse_arguments()
 
     if args.force_color:
@@ -135,6 +123,9 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
         if mode not in ('auto', 'full', 'compact'):
             mode = 'auto'
         args.monitor = mode
+
+    if not setlocale_utf8():
+        args.ascii = True
 
     try:
         device_count = Device.count()

--- a/nvitop/gui/__init__.py
+++ b/nvitop/gui/__init__.py
@@ -3,5 +3,6 @@
 
 # pylint: disable=missing-module-docstring
 
-from nvitop.gui.library import Device, libcurses, colored, set_color, USERNAME, SUPERUSER
+from nvitop.gui.library import (Device, libcurses, setlocale_utf8,
+                                colored, set_color, USERNAME, SUPERUSER)
 from nvitop.gui.top import Top

--- a/nvitop/gui/library/__init__.py
+++ b/nvitop/gui/library/__init__.py
@@ -5,7 +5,7 @@
 
 from nvitop.gui.library.device import Device, NA
 from nvitop.gui.library.process import host, HostProcess, GpuProcess, Snapshot, bytes2human
-from nvitop.gui.library.libcurses import libcurses
+from nvitop.gui.library.libcurses import libcurses, setlocale_utf8
 from nvitop.gui.library.displayable import Displayable, DisplayableContainer
 from nvitop.gui.library.keybinding import (ALT_KEY, ANYKEY, PASSIVE_ACTION, QUANT_KEY,
                                            SPECIAL_KEYS, KeyBuffer, KeyMaps)

--- a/nvitop/gui/library/libcurses.py
+++ b/nvitop/gui/library/libcurses.py
@@ -82,19 +82,23 @@ def _get_color_attr(fg=-1, bg=-1, attr=0):
     return curses.color_pair(_get_color(fg, bg)) | attr
 
 
+def setlocale_utf8():
+    for code in ('C.UTF-8', 'en_US.UTF-8', '', 'C'):
+        try:
+            code = locale.setlocale(locale.LC_ALL, code)
+        except locale.Error:
+            continue
+        else:
+            if 'utf8' in code.lower() or 'utf-8' in code.lower():
+                return True
+
+    return False
+
+
 @contextlib.contextmanager
 def libcurses(light_theme=False):
     os.environ.setdefault('ESCDELAY', '25')
-    try:
-        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
-    except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, 'C')
-        except locale.Error:
-            try:
-                locale.setlocale(locale.LC_ALL, '')
-            except locale.Error:
-                pass
+    setlocale_utf8()
 
     win = curses.initscr()
     win.nodelay(True)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: CentOS Linux release 7.9.2009 (Core)
- Terminal emulator and version: Windows Terminal 1.12.10732.0
- Python version: `3.6.8`
- NVML version (driver version): `512.15`
- `nvitop` version or commit: `dev@93926f3`
- `python-ml-py` version: `11.450.51`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

The fresh installed CentOS 7 does not have locale `C.UTF-8`.

```console
[root@centos /]# locale -a
C
en_US.utf8
POSIX
[root@centos /]# locale
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=en_US.UTF-8
[root@centos /]# 
```

`nvitop` sets the locale setting to `C` which does not support Unicode box-drawing characters. However the system default, which is `en_US.utf8`, does support Unicode characters.

https://github.com/XuehaiPan/nvitop/blob/93926f3865015cc02550ee7e27f5ce3a73adf8aa/nvitop/gui/library/libcurses.py#L88-L97

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Reorder locale encoding detection. Let the system default (`setlocale(LC_ALL, '')`) precedes `setlocale(LC_ALL, 'C')`. Fix box-drawing on CentOS 7.

Fixes #14

#### Testing

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Tested on CentOS 7 docker container.

#### Images / Videos  <!-- Only if relevant -->

<!-- Link or embed images and videos of screenshots, sketches etc. -->

Set locale to `C`:

![Screenshot 1](https://user-images.githubusercontent.com/16078332/163951408-5a4bab8c-d69d-4d8c-a8ab-4a623b5ef41c.png)

Set locale to system default:

![Screenshot 2](https://user-images.githubusercontent.com/16078332/163951461-01169a28-6ef5-477b-b9b5-87f229b3874f.png)
