### PR TITLE
refactor(core/libnvml): use module-based approach rather than singleton

### DIFF
--- a/docs/source/apis/core/libnvml.rst
+++ b/docs/source/apis/core/libnvml.rst
@@ -6,4 +6,3 @@ nvitop.core.libnvml module
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
-    :noindex: pynvml.NVMLError

--- a/nvitop/callbacks/keras.py
+++ b/nvitop/callbacks/keras.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Tuple, Union
 
 from tensorflow.python.keras.callbacks import Callback  # pylint: disable=import-error,no-name-in-module
 
-from nvitop.core import nvml
+from nvitop.core import libnvml
 from nvitop.callbacks.utils import get_devices_by_logical_ids, get_gpu_stats
 
 
@@ -89,8 +89,8 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         super().__init__()
 
         try:
-            nvml.nvmlInit()
-        except nvml.NVMLError as ex:
+            libnvml.nvmlInit()
+        except libnvml.NVMLError as ex:
             raise ValueError(
                 'Cannot use the GpuStatsLogger callback because the NVIDIA driver is not installed.'
             ) from ex
@@ -106,7 +106,7 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
 
         try:
             self._devices = get_devices_by_logical_ids(gpu_ids, unique=True)
-        except (nvml.NVMLError, RuntimeError) as ex:
+        except (libnvml.NVMLError, RuntimeError) as ex:
             raise ValueError(
                 'Cannot use GpuStatsLogger callback because devices unavailable. '
                 'Received: `gpus={}`'.format(gpu_ids)

--- a/nvitop/callbacks/pytorch_lightning.py
+++ b/nvitop/callbacks/pytorch_lightning.py
@@ -11,7 +11,7 @@ from pytorch_lightning.callbacks import Callback                              # 
 from pytorch_lightning.utilities import rank_zero_only                        # pylint: disable=import-error
 from pytorch_lightning.utilities.exceptions import MisconfigurationException  # pylint: disable=import-error
 
-from nvitop.core import nvml
+from nvitop.core import libnvml
 from nvitop.callbacks.utils import get_devices_by_logical_ids, get_gpu_stats
 
 
@@ -77,8 +77,8 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         super().__init__()
 
         try:
-            nvml.nvmlInit()
-        except nvml.NVMLError as ex:
+            libnvml.nvmlInit()
+        except libnvml.NVMLError as ex:
             raise MisconfigurationException(
                 'Cannot use GpuStatsLogger callback because NVIDIA driver is not installed.'
             ) from ex
@@ -103,7 +103,7 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         device_ids = trainer.data_parallel_device_ids
         try:
             self._devices = get_devices_by_logical_ids(device_ids, unique=True)
-        except (nvml.NVMLError, RuntimeError) as ex:
+        except (libnvml.NVMLError, RuntimeError) as ex:
             raise ValueError(
                 'Cannot use GpuStatsLogger callback because devices unavailable. '
                 'Received: `gpus={}`'.format(device_ids)

--- a/nvitop/cli.py
+++ b/nvitop/cli.py
@@ -8,7 +8,7 @@ import curses
 import os
 import sys
 
-from nvitop.core import nvml, HostProcess, boolify
+from nvitop.core import libnvml, HostProcess, boolify
 from nvitop.gui import Top, Device, libcurses, setlocale_utf8, colored, set_color, USERNAME
 from nvitop.version import __version__
 
@@ -140,9 +140,9 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
 
     try:
         device_count = Device.count()
-    except nvml.NVMLError_LibraryNotFound:  # pylint: disable=no-member
+    except libnvml.NVMLError_LibraryNotFound:  # pylint: disable=no-member
         return 1
-    except nvml.NVMLError as e:             # pylint: disable=invalid-name
+    except libnvml.NVMLError as e:             # pylint: disable=invalid-name
         print('{} {}'.format(colored('NVML ERROR:', color='red', attrs=('bold',)), e), file=sys.stderr)
         return 1
 
@@ -207,14 +207,14 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
     top.print()
     top.destroy()
 
-    if len(nvml.UNKNOWN_FUNCTIONS) > 0:
+    if len(libnvml.UNKNOWN_FUNCTIONS) > 0:
         unknown_function_messages = [
             'ERROR: Some FunctionNotFound errors occurred while calling:'
-            if len(nvml.UNKNOWN_FUNCTIONS) > 1
+            if len(libnvml.UNKNOWN_FUNCTIONS) > 1
             else 'ERROR: A FunctionNotFound error occurred while calling:'
         ]
         unknown_function_messages.extend('    nvmlQuery({.__name__!r}, *args, **kwargs)'.format(func)
-                                         for func, _ in nvml.UNKNOWN_FUNCTIONS.values())
+                                         for func, _ in libnvml.UNKNOWN_FUNCTIONS.values())
         unknown_function_messages.append('\n'.join((
             'Please verify whether the `{0}` package is compatible with your NVIDIA driver version.',
             'You can check the release history of `{0}` and install the compatible version manually.',

--- a/nvitop/core/__init__.py
+++ b/nvitop/core/__init__.py
@@ -3,8 +3,8 @@
 
 """The core APIs of nvitop."""
 
-from nvitop.core import host, utils
-from nvitop.core.libnvml import libnvml, nvmlCheckReturn, NVMLError
+from nvitop.core import host, libnvml, utils
+from nvitop.core.libnvml import nvmlCheckReturn, NVMLError
 from nvitop.core.device import Device, PhysicalDevice, MigDevice, CudaDevice, CudaMigDevice
 from nvitop.core.process import HostProcess, GpuProcess, command_join
 from nvitop.core.collector import take_snapshots, ResourceMetricCollector

--- a/nvitop/core/__init__.py
+++ b/nvitop/core/__init__.py
@@ -4,7 +4,7 @@
 """The core APIs of nvitop."""
 
 from nvitop.core import host, utils
-from nvitop.core.libnvml import nvml, nvmlCheckReturn, NVMLError
+from nvitop.core.libnvml import libnvml, nvmlCheckReturn, NVMLError
 from nvitop.core.device import Device, PhysicalDevice, MigDevice, CudaDevice, CudaMigDevice
 from nvitop.core.process import HostProcess, GpuProcess, command_join
 from nvitop.core.collector import take_snapshots, ResourceMetricCollector
@@ -12,7 +12,7 @@ from nvitop.core.utils import *
 
 
 __all__ = ['take_snapshots', 'ResourceMetricCollector',
-           'nvml', 'nvmlCheckReturn', 'NVMLError',
+           'libnvml', 'nvmlCheckReturn', 'NVMLError',
            'Device', 'PhysicalDevice', 'MigDevice', 'CudaDevice', 'CudaMigDevice',
            'host', 'HostProcess', 'GpuProcess', 'command_join']
 __all__.extend(utils.__all__)

--- a/nvitop/core/device.py
+++ b/nvitop/core/device.py
@@ -97,7 +97,7 @@ from typing import List, Tuple, Dict, Iterable, NamedTuple, Callable, Union, Opt
 
 from cachetools.func import ttl_cache
 
-from nvitop.core.libnvml import libnvml
+from nvitop.core import libnvml
 from nvitop.core.process import GpuProcess
 from nvitop.core.utils import (NA, NaType, Snapshot, bytes2human,
                                boolify, memoize_when_activated)

--- a/nvitop/core/host.py
+++ b/nvitop/core/host.py
@@ -74,3 +74,6 @@ else:
     WSL = None
 WINDOWS_SUBSYSTEM_FOR_LINUX = WSL
 """The Linux distribution name of the Windows Subsystem for Linux."""
+
+
+del _os, _defaultdict, _ttl_cache

--- a/nvitop/core/libnvml.py
+++ b/nvitop/core/libnvml.py
@@ -1,74 +1,308 @@
 # This file is part of nvitop, the interactive NVIDIA-GPU process viewer.
 # License: GNU GPL version 3.
 
-"""Utilities for the NVML Python bindings."""
+"""Utilities for the NVML Python bindings (`nvidia-ml-py <https://pypi.org/project/nvidia-ml-py>`_)."""
 
 # pylint: disable=invalid-name
 
-import inspect
-import logging
-import re
-import threading
-from types import FunctionType
-from typing import Tuple, Callable, Union, Optional, Any
+import inspect as _inspect
+import logging as _logging
+import re as _re
+import sys as _sys
+import threading as _threading
+from types import FunctionType as _FunctionType, ModuleType as _ModuleType
+from typing import (Tuple as _Tuple, Callable as _Callable, Type as _Type,
+                    Union as _Union, Optional as _Optional, Any as _Any)
 
 # Python Bindings for the NVIDIA Management Library (NVML)
 # https://pypi.org/project/nvidia-ml-py
-import pynvml
+import pynvml as _pynvml
 
-from nvitop.core.utils import NA, colored
-
-
-__all__ = ['LibnvmlSingleton', 'libnvml', 'nvmlCheckReturn', 'NVMLError']
+from nvitop.core.utils import NA, colored as __colored
 
 
-class LibnvmlSingleton:
-    """The helper singleton class that holds members from
-    package `nvidia-ml-py <https://pypi.org/project/nvidia-ml-py>`_.
+__all__ = ['NA', 'nvmlCheckReturn', 'nvmlQuery', 'nvmlInit', 'nvmlInitWithFlags', 'nvmlShutdown', 'NVMLError']
+
+
+NVMLError = _pynvml.NVMLError
+NVMLError.__doc__ = """Base exception class for NVML query errors."""
+NVMLError.__new__.__doc__ = """Maps value to a proper subclass of :class:`NVMLError`."""
+nvmlExceptionClass = _pynvml.nvmlExceptionClass
+nvmlExceptionClass.__doc__ = """Maps value to a proper subclass of :class:`NVMLError`."""
+
+# Load members from module `pynvml` and register them in `__all__`.
+_name = _attr = None
+_errcode_to_name = {}
+# Put error classes in `__all__` first
+for _name, _attr in vars(_pynvml).items():
+    if _name in ('nvmlInit', 'nvmlInitWithFlags', 'nvmlShutdown'):
+        continue
+    if _name.startswith('NVML_ERROR_') or _name.startswith('NVMLError_'):
+        globals()[_name] = _attr
+        __all__.append(_name)
+        if _name.startswith('NVML_ERROR_'):
+            _errcode_to_name[_attr] = _name
+# Then the remaining members
+for _name, _attr in vars(_pynvml).items():
+    if _name in ('nvmlInit', 'nvmlInitWithFlags', 'nvmlShutdown'):
+        continue
+    if (
+        _name.startswith('NVML_') and not _name.startswith('NVML_ERROR_')
+    ) or (
+        _name.startswith('nvml') and isinstance(_attr, _FunctionType)
+    ):
+        globals()[_name] = _attr
+        __all__.append(_name)
+del _name, _attr
+
+# Add docstring to exception classes
+_errcode = _reason = None
+for _errcode, _reason in NVMLError._errcode_to_string.items():  # pylint: disable=protected-access
+    _subclass = _pynvml.nvmlExceptionClass(_errcode)
+    _subclass.__doc__ = '{}. Code: :data:`{}` (:data:`{}`)'.format(_reason.rstrip('.'),
+                                                                   _errcode_to_name[_errcode],
+                                                                   _errcode)
+del _errcode, _reason, _errcode_to_name
+
+# Add explicit references to appease linters
+c_nvmlDevice_t = _pynvml.c_nvmlDevice_t
+NVMLError_LibraryNotFound = _pynvml.NVMLError_LibraryNotFound  # pylint: disable=no-member
+NVMLError_FunctionNotFound = _pynvml.NVMLError_FunctionNotFound  # pylint: disable=no-member
+
+
+# Module attributes
+__flags = []
+__initialized = False
+__lock = _threading.Lock()
+
+LOGGER = _logging.getLogger(__name__)
+UNKNOWN_FUNCTIONS = {}
+UNKNOWN_FUNCTIONS_CACHE_SIZE = 1024
+VERSIONED_PATTERN = _re.compile(r'^(?P<name>\w+)(?P<suffix>_v(\d)+)$')
+
+
+def _lazy_init() -> None:
+    """Lazily initializes the NVML context."""
+
+    with __lock:
+        if __initialized:
+            return
+    nvmlInit()
+
+
+def nvmlInit() -> None:
+    """Initializes the NVML context with default flag (0).
+
+    Raises:
+        NVMLError_LibraryNotFound:
+            If cannot find the NVML library, usually the NVIDIA driver is not installed.
+        NVMLError_DriverNotLoaded:
+            If NVIDIA driver is not loaded.
+        NVMLError_LibRmVersionMismatch:
+            If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
+            driver without reloading the kernel module.
+        AttributeError:
+            If cannot find function :func:`pynvml.nvmlInitWithFlags`, usually the :mod:`pynvml` module
+            is overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
     """
 
-    NVMLError = pynvml.NVMLError
-    """Base exception class for NVML query errors."""
+    nvmlInitWithFlags(0)
 
-    LOGGER = logging.getLogger('NVML')
-    UNKNOWN_FUNCTIONS = {}
-    UNKNOWN_FUNCTIONS_CACHE_SIZE = 1024
-    VERSIONED_PATTERN = re.compile(r'^(?P<name>\w+)(?P<suffix>_v(\d)+)$')
 
-    c_nvmlDevice_t = pynvml.c_nvmlDevice_t
+def nvmlInitWithFlags(flags: int) -> None:
+    """Initializes the NVML context with the given flags.
 
-    def __new__(cls) -> 'LibnvmlSingleton':
-        """Gets the singleton instance of :class:`LibnvmlSingleton`."""
+    Raises:
+        NVMLError_LibraryNotFound:
+            If cannot find the NVML library, usually the NVIDIA driver is not installed.
+        NVMLError_DriverNotLoaded:
+            If NVIDIA driver is not loaded.
+        NVMLError_LibRmVersionMismatch:
+            If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
+            driver without reloading the kernel module.
+        AttributeError:
+            If cannot find function :func:`pynvml.nvmlInitWithFlags`, usually the :mod:`pynvml` module
+            is overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
+    """
 
-        if not hasattr(cls, '_instance'):
-            instance = cls._instance = super().__new__(cls)
-            instance._flags = []
-            instance._initialized = False
-            instance._lock = threading.Lock()
-            for name, attr in vars(pynvml).items():
-                if name in ('nvmlInit', 'nvmlInitWithFlags', 'nvmlShutdown'):
-                    continue
+    global __flags, __initialized  # pylint: disable=global-statement,global-variable-not-assigned
+
+    with __lock:
+        if len(__flags) > 0 and flags == __flags[-1]:
+            __initialized = True
+            return
+
+    try:
+        _pynvml.nvmlInitWithFlags(flags)
+    except NVMLError_LibraryNotFound:
+        message = '\n'.join((
+            'FATAL ERROR: NVIDIA Management Library (NVML) not found.',
+            'HINT: The NVIDIA Management Library ships with the NVIDIA display driver (available at',
+            '      https://www.nvidia.com/Download/index.aspx), or can be downloaded as part of the',
+            '      NVIDIA CUDA Toolkit (available at https://developer.nvidia.com/cuda-downloads).',
+            '      The lists of OS platforms and NVIDIA-GPUs supported by the NVML library can be',
+            '      found in the NVML API Reference at https://docs.nvidia.com/deploy/nvml-api.',
+        ))
+        for text, color, attrs in (('FATAL ERROR:', 'red', ('bold',)),
+                                   ('HINT:', 'yellow', ('bold',)),
+                                   ('https://www.nvidia.com/Download/index.aspx', None, ('underline',)),
+                                   ('https://developer.nvidia.com/cuda-downloads', None, ('underline',)),
+                                   ('https://docs.nvidia.com/deploy/nvml-api', None, ('underline',))):
+            message = message.replace(text, __colored(text, color=color, attrs=attrs))
+
+        LOGGER.critical(message)
+        raise
+    except AttributeError:
+        message = '\n'.join((
+            'FATAL ERROR: The dependency package `nvidia-ml-py` is corrupted. You may have installed',
+            '             other packages overriding the module `pynvml`.',
+            'Please reinstall `nvitop` with command:',
+            '    python3 -m pip install --force-reinstall nvitop',
+        ))
+        for text, color, attrs in (('FATAL ERROR:', 'red', ('bold',)),
+                                   ('nvidia-ml-py', None, ('bold',)),
+                                   ('pynvml', None, ('bold',)),
+                                   ('nvitop', None, ('bold',))):
+            message = message.replace(text, __colored(text, color=color, attrs=attrs), 1)
+
+        LOGGER.critical(message)
+        raise
+    else:
+        with __lock:
+            __flags.append(flags)
+            __initialized = True
+
+
+def nvmlShutdown() -> None:
+    """Shutdowns the NVML context.
+
+    Raises:
+        NVMLError_LibraryNotFound:
+            If cannot find the NVML library, usually the NVIDIA driver is not installed.
+        NVMLError_DriverNotLoaded:
+            If NVIDIA driver is not loaded.
+        NVMLError_LibRmVersionMismatch:
+            If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
+            driver without reloading the kernel module.
+        NVMLError_Uninitialized:
+            If NVML was not first initialized with ``nvmlInit()``.
+    """
+
+    global __flags, __initialized  # pylint: disable=global-statement,global-variable-not-assigned
+
+    _pynvml.nvmlShutdown()
+    with __lock:
+        try:
+            __flags.pop()
+        except IndexError:
+            pass
+        __initialized = (len(__flags) > 0)
+
+
+def nvmlQuery(func: _Union[_Callable[..., _Any], str],
+              *args,
+              default: _Any = NA,
+              ignore_errors: bool = True,
+              ignore_function_not_found: bool = False,
+              **kwargs) -> _Any:
+    """Calls a function with the given arguments from NVML. The NVML context will be automatically
+    initialized.
+
+    Args:
+        func (Union[Callable[..., Any], str]):
+            The function to call. If it is given by string, lookup for the function first from
+            module :mod:`pynvml`.
+        default (Any):
+            The default value if the query fails.
+        ignore_errors (bool):
+            Whether to ignore errors and return the default value.
+        ignore_function_not_found (bool):
+            Whether to ignore function not found errors and return the default value. If set to
+            :data:`False`, an error message will be logged to the logger.
+        *args:
+            Positional arguments to pass to the query function.
+        **kwargs:
+            Keyword arguments to pass to the query function.
+    """
+
+    global UNKNOWN_FUNCTIONS  # pylint: disable=global-statement,global-variable-not-assigned
+
+    _lazy_init()
+
+    try:
+        if isinstance(func, str):
+            try:
+                func = getattr(__modself, func)
+            except AttributeError as e1:
+                raise NVMLError_FunctionNotFound from e1
+
+        retval = func(*args, **kwargs)
+    except NVMLError_FunctionNotFound as e2:
+        if not ignore_function_not_found:
+            if identifier.__name__ == '<lambda>':
+                identifier = _inspect.getsource(func)
+            else:
+                identifier = repr(func)
+            with __lock:
                 if (
-                    name.startswith('NVML_') or name.startswith('NVMLError_')
-                ) or (
-                    name.startswith('nvml') and isinstance(attr, FunctionType)
+                    identifier not in UNKNOWN_FUNCTIONS
+                    and len(UNKNOWN_FUNCTIONS) < UNKNOWN_FUNCTIONS_CACHE_SIZE
                 ):
-                    setattr(instance, name, attr)
+                    UNKNOWN_FUNCTIONS[identifier] = (func, e2)
+                    LOGGER.error(
+                        'ERROR: A FunctionNotFound error occurred while calling %s.\n'
+                        'Please verify whether the `nvidia-ml-py` package is '
+                        'compatible with your NVIDIA driver version.',
+                        'nvmlQuery({!r}, *args, **kwargs)'.format(func)
+                    )
+        if ignore_errors or ignore_function_not_found:
+            return default
+        raise
+    except NVMLError:
+        if ignore_errors:
+            return default
+        raise
+    else:
+        if isinstance(retval, bytes):
+            retval = retval.decode('UTF-8')
+        return retval
 
-        return cls._instance
 
-    def __del__(self) -> None:
-        """Automatically shutdowns the NVML context on destruction."""
+def nvmlCheckReturn(retval: _Any, types: _Optional[_Union[_Type, _Tuple[_Type, ...]]] = None) -> bool:
+    """Checks the return value is not :const:`nvitop.NA` and is one of the given types."""
+
+    if types is None:
+        return retval != NA
+    return retval != NA and isinstance(retval, types)
+
+
+# Add support for lookup fallback and context manager.
+class _CustomModule(_ModuleType):
+    """Modified module type to support lookup fallback and context manager.
+
+    Automatic lookup fallback:
+
+        >>> libnvml.c_nvmlGpuInstance_t  # fallback to pynvml.c_nvmlGpuInstance_t
+        <class 'pynvml.LP_struct_c_nvmlGpuInstance_t'>
+
+    Context manager:
+
+        >>> with libnvml:
+        ...     handle = libnvml.nvmlDeviceGetHandleByIndex(0)
+        ... # The NVML context has been shutdown
+    """
+
+    def __getattribute__(self, name: str) -> _Union[_Any, _Callable[..., _Any]]:
+        """Gets a member from the current module. Fallback to the original package if missing."""
 
         try:
-            self.nvmlShutdown()
-        except libnvml.NVMLError:
-            pass
+            return super().__getattribute__(name)
+        except AttributeError:
+            return getattr(_pynvml, name)
 
-    def __enter__(self) -> 'LibnvmlSingleton':
+    def __enter__(self) -> '_CustomModule':
         """Entry of the context manager for ``with`` statement."""
 
-        self._lazy_init()
         return self
 
     def __exit__(self, *args, **kwargs) -> None:
@@ -76,202 +310,20 @@ class LibnvmlSingleton:
 
         self.__del__()
 
-    def __getattr__(self, name: str) -> Union[Any, Callable[..., Any]]:
-        """Gets a member from the instance. Fallback to the original package if missing."""
+    def __del__(self) -> None:
+        """Automatically shutdowns the NVML context on destruction."""
 
         try:
-            return super().__getattr__(name)
-        except AttributeError:
-            return getattr(pynvml, name)
-
-    def _lazy_init(self) -> None:
-        """Lazily initializes the NVML context."""
-
-        with self._lock:
-            if self._initialized:
-                return
-        self.nvmlInit()
-
-    def nvmlInit(self) -> None:
-        """Initializes the NVML context with default flag (0).
-
-        Raises:
-            NVMLError_LibraryNotFound:
-                If cannot find the NVML library, usually the NVIDIA driver is not installed.
-            NVMLError_DriverNotLoaded:
-                If NVIDIA driver is not loaded.
-            NVMLError_LibRmVersionMismatch:
-                If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
-                driver without reloading the kernel module.
-            AttributeError:
-                If cannot find function ``nvmlInitWithFlags``, usually the ``pynvml`` module is
-                overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
-        """
-
-        self.nvmlInitWithFlags(0)
-
-    def nvmlInitWithFlags(self, flags: int) -> None:
-        """Initializes the NVML context with the given flags.
-
-        Raises:
-            NVMLError_LibraryNotFound:
-                If cannot find the NVML library, usually the NVIDIA driver is not installed.
-            NVMLError_DriverNotLoaded:
-                If NVIDIA driver is not loaded.
-            NVMLError_LibRmVersionMismatch:
-                If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
-                driver without reloading the kernel module.
-            AttributeError:
-                If cannot find function ``nvmlInitWithFlags``, usually the ``pynvml`` module is
-                overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
-        """
-
-        with self._lock:
-            if len(self._flags) > 0 and flags == self._flags[-1]:
-                self._initialized = True  # pylint: disable=attribute-defined-outside-init
-                return
-
-        try:
-            pynvml.nvmlInitWithFlags(flags)
-        except libnvml.NVMLError_LibraryNotFound:  # pylint: disable=no-member
-            message = '\n'.join((
-                'FATAL ERROR: NVIDIA Management Library (NVML) not found.',
-                'HINT: The NVIDIA Management Library ships with the NVIDIA display driver (available at',
-                '      https://www.nvidia.com/Download/index.aspx), or can be downloaded as part of the',
-                '      NVIDIA CUDA Toolkit (available at https://developer.nvidia.com/cuda-downloads).',
-                '      The lists of OS platforms and NVIDIA-GPUs supported by the NVML library can be',
-                '      found in the NVML API Reference at https://docs.nvidia.com/deploy/nvml-api.',
-            ))
-            for text, color, attrs in (('FATAL ERROR:', 'red', ('bold',)),
-                                       ('HINT:', 'yellow', ('bold',)),
-                                       ('https://www.nvidia.com/Download/index.aspx', None, ('underline',)),
-                                       ('https://developer.nvidia.com/cuda-downloads', None, ('underline',)),
-                                       ('https://docs.nvidia.com/deploy/nvml-api', None, ('underline',))):
-                message = message.replace(text, colored(text, color=color, attrs=attrs))
-
-            self.LOGGER.critical(message)
-            raise
-        except AttributeError:
-            message = '\n'.join((
-                'FATAL ERROR: The dependency package `nvidia-ml-py` is corrupted. You may have installed',
-                '             other packages overriding the module `pynvml`.',
-                'Please reinstall `nvitop` with command:',
-                '    python3 -m pip install --force-reinstall nvitop',
-            ))
-            for text, color, attrs in (('FATAL ERROR:', 'red', ('bold',)),
-                                       ('nvidia-ml-py', None, ('bold',)),
-                                       ('pynvml', None, ('bold',)),
-                                       ('nvitop', None, ('bold',))):
-                message = message.replace(text, colored(text, color=color, attrs=attrs), 1)
-
-            self.LOGGER.critical(message)
-            raise
-        else:
-            with self._lock:
-                self._flags.append(flags)
-                self._initialized = True  # pylint: disable=attribute-defined-outside-init
-
-    def nvmlShutdown(self) -> None:
-        """Shutdowns the NVML context.
-
-        Raises:
-            NVMLError_LibraryNotFound:
-                If cannot find the NVML library, usually the NVIDIA driver is not installed.
-            NVMLError_DriverNotLoaded:
-                If NVIDIA driver is not loaded.
-            NVMLError_LibRmVersionMismatch:
-                If RM detects a driver/library version mismatch, usually after an upgrade for NVIDIA
-                driver without reloading the kernel module.
-            NVMLError_Uninitialized:
-                If NVML was not first initialized with ``nvmlInit()``.
-        """
-
-        pynvml.nvmlShutdown()
-        with self._lock:
-            try:
-                self._flags.pop()
-            except IndexError:
-                pass
-            self._initialized = (len(self._flags) > 0)  # pylint: disable=attribute-defined-outside-init
-
-    def nvmlQuery(self, func: Union[Callable[..., Any], str],
-                  *args,
-                  default: Any = NA,
-                  ignore_errors: bool = True,
-                  ignore_function_not_found: bool = False,
-                  **kwargs) -> Any:
-        """Calls a function with the given arguments from NVML. The NVML context will be lazily initialized.
-
-        Args:
-            func (Union[Callable[..., Any], str]):
-                The function to call. If it is given by string, lookup for the
-                function first from ``pynvml``.
-            default (Any):
-                The default value if the query fails.
-            ignore_errors (bool):
-                Whether to ignore errors and return the default value.
-            ignore_function_not_found (bool):
-                Whether to ignore function not found errors and return the
-                default value. If set to :data:`False`, a error message will be logged
-                to the logger.
-            *args:
-                Positional arguments to pass to the query function.
-            **kwargs:
-                Keyword arguments to pass to the query function.
-        """
-
-        self._lazy_init()
-
-        try:
-            if isinstance(func, str):
-                try:
-                    func = getattr(self, func)
-                except AttributeError as e1:
-                    raise libnvml.NVMLError_FunctionNotFound from e1  # pylint: disable=no-member
-
-            retval = func(*args, **kwargs)
-        except libnvml.NVMLError_FunctionNotFound as e2:  # pylint: disable=no-member
-            if not ignore_function_not_found:
-                if identifier.__name__ == '<lambda>':
-                    identifier = inspect.getsource(func)
-                else:
-                    identifier = repr(func)
-                with self._lock:
-                    if (
-                        identifier not in self.UNKNOWN_FUNCTIONS
-                        and len(self.UNKNOWN_FUNCTIONS) < self.UNKNOWN_FUNCTIONS_CACHE_SIZE
-                    ):
-                        self.UNKNOWN_FUNCTIONS[identifier] = (func, e2)
-                        self.LOGGER.error(
-                            'ERROR: A FunctionNotFound error occurred while calling %s.\n'
-                            'Please verify whether the `nvidia-ml-py` package is '
-                            'compatible with your NVIDIA driver version.',
-                            'nvmlQuery({!r}, *args, **kwargs)'.format(func)
-                        )
-            if ignore_errors or ignore_function_not_found:
-                return default
-            raise
-        except libnvml.NVMLError:
-            if ignore_errors:
-                return default
-            raise
-        else:
-            if isinstance(retval, bytes):
-                retval = retval.decode('UTF-8')
-            return retval
-
-    @staticmethod
-    def nvmlCheckReturn(retval: Any, types: Optional[Union[type, Tuple[type, ...]]] = None) -> bool:
-        """Checks the return value is not :const:`nvitop.NA` and is one of the given types."""
-
-        if types is None:
-            return retval != NA
-        return retval != NA and isinstance(retval, types)
+            nvmlShutdown()
+        except NVMLError:
+            pass
 
 
-libnvml = LibnvmlSingleton()
-"""The singleton instance of class :class:`LibnvmlSingleton`."""
+# Replace entry in sys.modules for this module with an instance of _CustomModule
+__modself = _sys.modules[__name__]
+__modself.__class__ = _CustomModule
+del _CustomModule
 
-nvmlCheckReturn = libnvml.nvmlCheckReturn
-
-NVMLError = libnvml.NVMLError
+del _inspect, _logging, _re, _sys, _threading
+del _FunctionType, _ModuleType
+del _Tuple, _Callable, _Type, _Union, _Optional, _Any

--- a/nvitop/core/libnvml.py
+++ b/nvitop/core/libnvml.py
@@ -19,11 +19,13 @@ import pynvml
 from nvitop.core.utils import NA, colored
 
 
-__all__ = ['libnvml', 'nvml', 'nvmlCheckReturn', 'NVMLError']
+__all__ = ['LibnvmlSingleton', 'libnvml', 'nvmlCheckReturn', 'NVMLError']
 
 
-class libnvml:
-    """The helper singleton class that holds members from package ``nvidia-ml-py``."""
+class LibnvmlSingleton:
+    """The helper singleton class that holds members from
+    package `nvidia-ml-py <https://pypi.org/project/nvidia-ml-py>`_.
+    """
 
     NVMLError = pynvml.NVMLError
     """Base exception class for NVML query errors."""
@@ -35,8 +37,8 @@ class libnvml:
 
     c_nvmlDevice_t = pynvml.c_nvmlDevice_t
 
-    def __new__(cls) -> 'libnvml':
-        """Gets the singleton instance of :class:`libnvml`."""
+    def __new__(cls) -> 'LibnvmlSingleton':
+        """Gets the singleton instance of :class:`LibnvmlSingleton`."""
 
         if not hasattr(cls, '_instance'):
             instance = cls._instance = super().__new__(cls)
@@ -60,10 +62,10 @@ class libnvml:
 
         try:
             self.nvmlShutdown()
-        except nvml.NVMLError:
+        except libnvml.NVMLError:
             pass
 
-    def __enter__(self) -> 'libnvml':
+    def __enter__(self) -> 'LibnvmlSingleton':
         """Entry of the context manager for ``with`` statement."""
 
         self._lazy_init()
@@ -131,7 +133,7 @@ class libnvml:
 
         try:
             pynvml.nvmlInitWithFlags(flags)
-        except nvml.NVMLError_LibraryNotFound:  # pylint: disable=no-member
+        except libnvml.NVMLError_LibraryNotFound:  # pylint: disable=no-member
             message = '\n'.join((
                 'FATAL ERROR: NVIDIA Management Library (NVML) not found.',
                 'HINT: The NVIDIA Management Library ships with the NVIDIA display driver (available at',
@@ -225,10 +227,10 @@ class libnvml:
                 try:
                     func = getattr(self, func)
                 except AttributeError as e1:
-                    raise nvml.NVMLError_FunctionNotFound from e1  # pylint: disable=no-member
+                    raise libnvml.NVMLError_FunctionNotFound from e1  # pylint: disable=no-member
 
             retval = func(*args, **kwargs)
-        except nvml.NVMLError_FunctionNotFound as e2:  # pylint: disable=no-member
+        except libnvml.NVMLError_FunctionNotFound as e2:  # pylint: disable=no-member
             if not ignore_function_not_found:
                 if identifier.__name__ == '<lambda>':
                     identifier = inspect.getsource(func)
@@ -249,7 +251,7 @@ class libnvml:
             if ignore_errors or ignore_function_not_found:
                 return default
             raise
-        except nvml.NVMLError:
+        except libnvml.NVMLError:
             if ignore_errors:
                 return default
             raise
@@ -267,9 +269,9 @@ class libnvml:
         return retval != NA and isinstance(retval, types)
 
 
-nvml = libnvml()
-"""The singleton instance of class :class:`libnvml`."""
+libnvml = LibnvmlSingleton()
+"""The singleton instance of class :class:`LibnvmlSingleton`."""
 
-nvmlCheckReturn = nvml.nvmlCheckReturn
+nvmlCheckReturn = libnvml.nvmlCheckReturn
 
-NVMLError = nvml.NVMLError
+NVMLError = libnvml.NVMLError

--- a/nvitop/core/process.py
+++ b/nvitop/core/process.py
@@ -16,7 +16,7 @@ from typing import List, Tuple, Dict, Iterable, Callable, Union, Optional, Type,
 from weakref import WeakValueDictionary
 
 from nvitop.core import host
-from nvitop.core.libnvml import nvml
+from nvitop.core.libnvml import libnvml
 from nvitop.core.utils import (NA, NaType, Snapshot,
                                bytes2human, timedelta2human,
                                memoize_when_activated)
@@ -602,7 +602,7 @@ class GpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._gpu_memory_human = bytes2human(self.gpu_memory())  # pylint: disable=attribute-defined-outside-init
         memory_total = self.device.memory_total()
         gpu_memory_percent = NA
-        if nvml.nvmlCheckReturn(memory_used, int) and nvml.nvmlCheckReturn(memory_total, int):
+        if libnvml.nvmlCheckReturn(memory_used, int) and libnvml.nvmlCheckReturn(memory_total, int):
             gpu_memory_percent = round(100.0 * memory_used / memory_total, 1)
         self._gpu_memory_percent = gpu_memory_percent  # pylint: disable=attribute-defined-outside-init
 

--- a/nvitop/core/process.py
+++ b/nvitop/core/process.py
@@ -15,8 +15,7 @@ from types import FunctionType
 from typing import List, Tuple, Dict, Iterable, Callable, Union, Optional, Type, Any, TYPE_CHECKING
 from weakref import WeakValueDictionary
 
-from nvitop.core import host
-from nvitop.core.libnvml import libnvml
+from nvitop.core import host, libnvml
 from nvitop.core.utils import (NA, NaType, Snapshot,
                                bytes2human, timedelta2human,
                                memoize_when_activated)

--- a/nvitop/gui/library/device.py
+++ b/nvitop/gui/library/device.py
@@ -3,7 +3,7 @@
 
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
-from nvitop.core import (nvml, PhysicalDevice as DeviceBase, MigDevice as MigDeviceBase,
+from nvitop.core import (libnvml, PhysicalDevice as DeviceBase, MigDevice as MigDeviceBase,
                          NA, Snapshot, utilization2string)
 from nvitop.gui.library.process import GpuProcess
 
@@ -70,7 +70,7 @@ class Device(DeviceBase):
             for mig_index in range(self.max_mig_device_count()):
                 try:
                     mig_device = MigDevice(index=(self.index, mig_index))
-                except nvml.NVMLError:
+                except libnvml.NVMLError:
                     break
                 else:
                     mig_devices.append(mig_device)
@@ -91,7 +91,7 @@ class Device(DeviceBase):
 
     def temperature_string(self):  # in Celsius
         temperature = self.temperature()
-        if nvml.nvmlCheckReturn(temperature, int):
+        if libnvml.nvmlCheckReturn(temperature, int):
             temperature = str(temperature) + 'C'
         return temperature
 

--- a/nvitop/version.py
+++ b/nvitop/version.py
@@ -51,9 +51,10 @@ or
 
 Note:
     The package ``nvidia-ml-py`` is not backward compatible over releases. This may cause problems
-    such as *"Function Not Found"* errors with Old versions of NVIDIA drivers (e.g. the NVIDIA R430
+    such as *"Function Not Found"* errors with old versions of NVIDIA drivers (e.g. the NVIDIA R430
     driver on Ubuntu 16.04 LTS).
     The ideal solution is to let the user install the best-fit version of ``nvidia-ml-py``.
+    See also: `nvidia-ml-py's Release History <https://pypi.org/project/nvidia-ml-py/#history>`_.
 
     ``nvidia-ml-py==11.450.51`` is the last version supports the NVIDIA R430 driver (CUDA 10.x).
     Since ``nvidia-ml-py>=11.450.129``, the definition of struct ``nvmlProcessInfo_t`` has introduced


### PR DESCRIPTION
#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Refactor

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.9.13`
- NVML version (driver version): `470.129.06`
- `nvitop` version or commit: `main@6bf151`
- `python-ml-py` version: `11.450.51`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

Use a module-based approach rather than a singleton class. Previously, we use a singleton class `libnvml` and the singleton `nvml` to support the context manager (`with` statement). Now, the mechanism is replaced by a custom module type.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Simplify module hierarchy. Make the IDE happy and let sphinx generate more documents from `autoapi`.