### PR TITLE
feat(core/libnvml): add compatibility layers for NVML Python bindings

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,8 @@
 
   1. Was this issue already reported? Please do a quick search.
   2. Maybe the problem is solved in the current master branch already?
-     Simply clone nvitop's git repository and run ./nvitop.py to find out.
+     Simply clone nvitop's git repository and run `LOGLEVEL=DEBUG ./nvitop.py`
+     to find out.
   3. Provide all the relevant information, as outlined in this template.
      Feel free to remove any sections you don't need.
 -->

--- a/README.md
+++ b/README.md
@@ -166,20 +166,6 @@ pip3 install .
   </br>
 </p>
 
-**IMPORTANT:** `pip` will install `nvidia-ml-py>=11.450.51,<=11.495.46` as a dependency for `nvitop`. Please verify whether the `nvidia-ml-py` package is compatible with your NVIDIA driver version. You can check the release history of `nvidia-ml-py` at [nvidia-ml-py's Release History](https://pypi.org/project/nvidia-ml-py/11.495.46/#history), and install the compatible version manually by:
-
-```bash
-pip3 install --no-dependencies 'nvidia-ml-py==xx.yyy.zzz'
-```
-
-Since `nvidia-ml-py>=11.450.129`, the definition of `nvmlProcessInfo_t` has introduced two new fields `gpuInstanceId` and `computeInstanceId` (`GI ID` and `CI ID` in newer `nvidia-smi`) which are incompatible with some old NVIDIA drivers. `nvitop` may not display the processes correctly due to this incompatibility.
-
-You can specified the version of `nvidia-ml-py` while installing `nvitop` as:
-
-```bash
-pip3 install 'nvitop[pynvml-11.450.51]'  # or 'nvitop[cuda10]'
-```
-
 ------
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ process filtering:
 | `NVITOP_MONITOR_MODE`                  | The default display mode (a comma-separated string) | `auto` / `full` / `compact`<br>`plain` / `colorful`<br>`dark` / `light` | `auto,plain,dark` |
 | `NVITOP_GPU_UTILIZATION_THRESHOLDS`    | Thresholds of GPU utilization                       | `10,75` , `1,99`, ...                                                   | `10,75`           |
 | `NVITOP_MEMORY_UTILIZATION_THRESHOLDS` | Thresholds of GPU memory percent                    | `10,80` , `1,99`, ...                                                   | `10,80`           |
+| `LOGLEVEL`                             | Log level for log messages                          | `DEBUG` , `INFO`, `WARNING`, ...                                        | `WARNING`         |
 
 For example:
 

--- a/nvitop/core/libnvml.py
+++ b/nvitop/core/libnvml.py
@@ -498,7 +498,9 @@ def __patch_backward_compatibility_layers() -> None:
             'nvmlDeviceGetMPSComputeRunningProcesses_v2': 'nvmlDeviceGetMPSComputeRunningProcesses',
         }
 
-        def callback(name, names, exception, pynvml, modself):  # pylint: disable=unused-argument
+        def patch_process_info_callback(
+            name, names, exception, pynvml, modself
+        ):  # pylint: disable=unused-argument
             if name in nvmlDeviceGetRunningProcesses_v3_v2:
                 mapping = nvmlDeviceGetRunningProcesses_v3_v2
                 struct_type = c_nvmlProcessInfo_v2_t
@@ -523,10 +525,11 @@ def __patch_backward_compatibility_layers() -> None:
         _pynvml.__dict__.update(  # need to use module.__dict__.__setitem__ because module.__setattr__ will not work
             # The patching ordering is important
             _nvmlGetFunctionPointer=patch_function_pointers_when_fail(
-                names=set(nvmlDeviceGetRunningProcesses_v3_v2), callback=callback
+                names=set(nvmlDeviceGetRunningProcesses_v3_v2), callback=patch_process_info_callback
             )(
                 patch_function_pointers_when_fail(
-                    names=set(nvmlDeviceGetRunningProcesses_v2_v1), callback=callback
+                    names=set(nvmlDeviceGetRunningProcesses_v2_v1),
+                    callback=patch_process_info_callback,
                 )(
                     _pynvml._nvmlGetFunctionPointer  # pylint: disable=protected-access
                 )

--- a/nvitop/version.py
+++ b/nvitop/version.py
@@ -49,6 +49,8 @@ PYNVML_VERSION_CANDIDATES = [
     '11.460.79',
     '11.470.66',
     '11.495.46',
+    '11.510.69',
+    '11.515.48',
 ]
 """The list of supported ``nvidia-ml-py`` versions.
 See also: `nvidia-ml-py's Release History <https://pypi.org/project/nvidia-ml-py/#history>`_.

--- a/nvitop/version.py
+++ b/nvitop/version.py
@@ -49,8 +49,9 @@ PYNVML_VERSION_CANDIDATES = [
     '11.460.79',
     '11.470.66',
     '11.495.46',
-    '11.510.69',
+    '11.510.69',  # the first version supports the `nvmlMemory_v2` API
     '11.515.48',
+    '11.515.75',
 ]
 """The list of supported ``nvidia-ml-py`` versions.
 See also: `nvidia-ml-py's Release History <https://pypi.org/project/nvidia-ml-py/#history>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "nvidia-ml-py >= 11.450.51, < 11.500.0a0",
+    "nvidia-ml-py >= 11.450.51, < 11.516.0a0",
     "psutil >= 5.6.6",
     "cachetools >= 1.0.1",
     "termcolor >= 1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nvidia-ml-py >= 11.450.51, < 11.500.0a0
+nvidia-ml-py >= 11.450.51, < 11.516.0a0
 psutil >= 5.6.6
 cachetools >= 1.0.1
 termcolor >= 1.0.0


### PR DESCRIPTION
#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### Runtime Environment

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.9.13`
- NVML version (driver version): `470.129.06`
- `nvitop` version or commit: `v0.7.1`
- `python-ml-py` version: `11.450.51`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

Automatically patch the `pynvml` module when the first call fails when calling the versioned APIs. Now we support a more broad range of the [PyPI package `nvidia-ml-py`](https://pypi.org/project/nvidia-ml-py/) dependency versions.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

See #29 for more details.

Resolves #29
Closes #13

#### Testing


Using `nvidia-ml-py == 11.515.48` with the NVIDIA R430 driver (CUDA 10.x):

```console
$ pip3 install --ignore-installed .
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Processing /home/panxuehai/Projects/nvitop
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Collecting psutil>=5.6.6
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/62/1f/f14225bda76417ab9bd808ff21d5cd59d5435a9796ca09b34d4cb0edcd88/psutil-5.9.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (281 kB)
Collecting cachetools>=1.0.1
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/68/aa/5fc646cae6e997c3adf3b0a7e257cda75cff21fcba15354dffd67789b7bb/cachetools-5.2.0-py3-none-any.whl (9.3 kB)
Collecting nvidia-ml-py<11.516.0a0,>=11.450.51
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/7c/b6/738d9c68f8abcdedf8901c4abf00df74e8f281626de67b5185dcc443e693/nvidia_ml_py-11.515.48-py3-none-any.whl (28 kB)
Collecting termcolor>=1.0.0
  Using cached termcolor-1.1.0-py3-none-any.whl
Building wheels for collected packages: nvitop
  Building wheel for nvitop (pyproject.toml) ... done
  Created wheel for nvitop: filename=nvitop-0.7.1+6.g0feed99-py3-none-any.whl size=154871 sha256=da07a27d8579e1cc38a3bd3d537f0d885d592df0c3293ba585b831fa236f100e
  Stored in directory: /tmp/pip-ephem-wheel-cache-3qzopv_e/wheels/9a/17/84/86d7a108dc1c0d7a25e96628d476e19df73a27353725b35779
Successfully built nvitop
Installing collected packages: termcolor, nvidia-ml-py, psutil, cachetools, nvitop
Successfully installed cachetools-5.2.0 nvidia-ml-py-11.515.48 nvitop-0.7.1+6.g84f43f5 psutil-5.9.1 termcolor-1.1.0
```

Result:

The v3 API `nvmlDeviceGetComputeRunningProcesses_v3` fails-back to v2 API `nvmlDeviceGetComputeRunningProcesses_v2` (which could not found either), then fails-back to v1 API `nvmlDeviceGetComputeRunningProcesses`.

```console
$ LOGLEVEL=DEBUG ./nvitop.py -1
Patching NVML function pointer `nvmlDeviceGetComputeRunningProcesses_v3`
    Map NVML function `nvmlDeviceGetComputeRunningProcesses_v3` to `nvmlDeviceGetComputeRunningProcesses_v2`
    Map NVML function `nvmlDeviceGetGraphicsRunningProcesses_v3` to `nvmlDeviceGetGraphicsRunningProcesses_v2`
    Map NVML function `nvmlDeviceGetMPSComputeRunningProcesses_v3` to `nvmlDeviceGetMPSComputeRunningProcesses_v2`
    Patch NVML struct `c_nvmlProcessInfo_t` to `c_nvmlProcessInfo_v2_t`
Patching NVML function pointer `nvmlDeviceGetComputeRunningProcesses_v2`
    Map NVML function `nvmlDeviceGetComputeRunningProcesses_v2` to `nvmlDeviceGetComputeRunningProcesses`
    Map NVML function `nvmlDeviceGetGraphicsRunningProcesses_v2` to `nvmlDeviceGetGraphicsRunningProcesses`
    Map NVML function `nvmlDeviceGetMPSComputeRunningProcesses_v2` to `nvmlDeviceGetMPSComputeRunningProcesses`
    Map NVML function `nvmlDeviceGetComputeRunningProcesses_v3` to `nvmlDeviceGetComputeRunningProcesses`
    Map NVML function `nvmlDeviceGetGraphicsRunningProcesses_v3` to `nvmlDeviceGetGraphicsRunningProcesses`
    Map NVML function `nvmlDeviceGetMPSComputeRunningProcesses_v3` to `nvmlDeviceGetMPSComputeRunningProcesses`
    Patch NVML struct `c_nvmlProcessInfo_t` to `c_nvmlProcessInfo_v1_t`
Sun Jul 24 19:32:24 2022
╒═════════════════════════════════════════════════════════════════════════════╕
│ NVIDIA-SMI 430.64       Driver Version: 430.64       CUDA Version: 10.1     │
├───────────────────────────────┬──────────────────────┬──────────────────────┤
│ GPU  Name        Persistence-M│ Bus-Id        Disp.A │ Volatile Uncorr. ECC │
│ Fan  Temp  Perf  Pwr:Usage/Cap│         Memory-Usage │ GPU-Util  Compute M. │
╞═══════════════════════════════╪══════════════════════╪══════════════════════╪══════════════════════════════════════════════════════════════════════════════════╕
│   0  TITAN Xp            Off  │ 00000000:05:00.0 Off │                  N/A │ MEM: ▏ 0.2%                                                                      │
│ 24%   43C    P8    19W / 250W │     19MiB / 12194MiB │      0%      Default │ UTL: ▏ 0%                                                                        │
├───────────────────────────────┼──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────────────────────────┤
│   1  TITAN Xp            Off  │ 00000000:06:00.0 Off │                  N/A │ MEM: ▏ 0.0%                                                                      │
│ 23%   36C    P8    10W / 250W │      2MiB / 12196MiB │      0%      Default │ UTL: ▏ 0%                                                                        │
├───────────────────────────────┼──────────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────────────────────────┤
│   2  ..orce GTX TITAN X  Off  │ 00000000:09:00.0 Off │                  N/A │ MEM: ▏ 0.0%                                                                      │
│ 22%   34C    P8    17W / 250W │      2MiB / 12213MiB │      0%      Default │ UTL: ▏ 0%                                                                        │
╘═══════════════════════════════╧══════════════════════╧══════════════════════╧══════════════════════════════════════════════════════════════════════════════════╛
[ CPU: █████▉ 5.3%                                                                                                          ]  ( Load Average:  0.89  0.61  0.39 )
[ MEM: ███▋ 3.2%                                                                                                            ]  [ SWP: ▏ 0.0%                     ]

╒════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╕
│ Processes:                                                                                                                                    panxuehai@ubuntu │
│ GPU     PID      USER  GPU-MEM %SM  %CPU  %MEM      TIME  COMMAND                                                                                              │
╞════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
│   0    2122 G    root    17MiB   0   0.0   0.0  4.2 days  /usr/lib/xorg/Xorg -core :0 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp vt7 -novtswitch │
╘════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╛
```
