### PR TITLE
feat(gui): add 256 color support for bar charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ pip3 install .
 <p align="center">
   <img width="100%" src="https://user-images.githubusercontent.com/16078332/178963038-a5cd4eb5-02a8-4456-966f-d5ff04eb44d8.png" alt="MIG Device Support">
   </br>
-  MIG Device Support
+  MIG Device Support.
   </br>
 </p>
 
@@ -233,6 +233,9 @@ $ nvitop -U  # useful for terminals without Unicode support
 
 # For light terminals
 $ nvitop --light
+
+# For spectrum-like bar charts (requires the terminal supports 256-color)
+$ nvitop --colorful
 ```
 
 You can configure the default monitor mode with the `NVITOP_MONITOR_MODE` environment variable (default `auto` if not set). See [Command Line Options and Environment Variables](#command-line-options-and-environment-variables) for more command options.
@@ -330,6 +333,12 @@ process filtering:
   --pid PID [PID ...], -p PID [PID ...]
                         Only show processes of the given PIDs.
 ```
+
+<p align="center">
+  <img width="100%" src="https://user-images.githubusercontent.com/16078332/182555606-8388e5a5-43a9-4990-90d4-46e45ac448a0.png" alt="Spectrum-like Bar Charts">
+  </br>
+  Spectrum-like bar charts (with option <code>--colorful</code>).
+</p>
 
 `nvitop` can accept the following environment variables for monitor mode:
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Type `nvitop --help` for more command options:
 usage: nvitop [--help] [--version] [--once] [--monitor [{auto,full,compact}]]
               [--interval SEC] [--ascii] [--colorful] [--force-color] [--light]
               [--gpu-util-thresh th1 th2] [--mem-util-thresh th1 th2]
-              [--only idx [idx ...]] [--only-visible] [--compute] [--graphics]
+              [--only idx [idx ...]] [--only-visible]
+              [--compute] [--no-compute] [--graphics] [--no-graphics]
               [--user [USERNAME ...]] [--pid PID [PID ...]]
 
 An interactive NVIDIA-GPU process viewer.
@@ -321,7 +322,9 @@ device filtering:
 
 process filtering:
   --compute, -c         Only show GPU processes with the compute context. (type: 'C' or 'C+G')
+  --no-compute, -C      Exclude GPU processes with the compute context. (type: 'G' only)
   --graphics, -g        Only show GPU processes with the graphics context. (type: 'G' or 'C+G')
+  --no-graphics, -G     Exclude GPU processes with the graphics context. (type: 'C' only)
   --user [USERNAME ...], -u [USERNAME ...]
                         Only show processes of the given users (or `$USER` for no argument).
   --pid PID [PID ...], -p PID [PID ...]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If this repo is useful to you, please star ⭐️ it to let more people know �
 
 - **Informative and fancy output**: show more information than `nvidia-smi` with colorized fancy box drawing.
 - **Monitor mode**: can run as a resource monitor, rather than print the results only once. (vs. [nvidia-htop](https://github.com/peci1/nvidia-htop), limited support with command `watch -c`)
-  - bar plots and history graphs
+  - bar charts and history graphs
   - process sorting
   - process filtering
   - send signals to processes with a keystroke
@@ -278,7 +278,7 @@ Type `nvitop --help` for more command options:
 
 ```text
 usage: nvitop [--help] [--version] [--once] [--monitor [{auto,full,compact}]]
-              [--interval SEC] [--ascii] [--force-color] [--light]
+              [--interval SEC] [--ascii] [--colorful] [--force-color] [--light]
               [--gpu-util-thresh th1 th2] [--mem-util-thresh th1 th2]
               [--only idx [idx ...]] [--only-visible] [--compute] [--graphics]
               [--user [USERNAME ...]] [--pid PID [PID ...]]
@@ -298,6 +298,10 @@ optional arguments:
                         Use ASCII characters only, which is useful for terminals without Unicode support.
 
 coloring:
+  --colorful            Use gradient colors to get spectrum-like bar charts. This option is only available
+                        when the terminal supports 256 colors. You may need to set environment variable
+                        `TERM="xterm-256color"`. Note that the terminal multiplexer, such as `tmux`, may
+                        override the `TREM` variable.
   --force-color         Force colorize even when `stdout` is not a TTY terminal.
   --light               Tweak visual results for light theme terminals in monitor mode.
                         Set variable `NVITOP_MONITOR_THEME="light"` on light terminals for convenience.

--- a/nvitop/cli.py
+++ b/nvitop/cli.py
@@ -88,6 +88,17 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
 
     coloring = parser.add_argument_group('coloring')
     coloring.add_argument(
+        '--colorful',
+        dest='colorful',
+        action='store_true',
+        help=(
+            'Use gradient colors to get spectrum-like bar charts. This option is only available\n'
+            'when the terminal supports 256 colors. You may need to set environment variable\n'
+            '`TERM="xterm-256color"`. Note that the terminal multiplexer, such as `tmux`, may\n'
+            'override the `TREM` variable.'
+        ),
+    )
+    coloring.add_argument(
         '--force-color',
         dest='force_color',
         action='store_true',
@@ -298,7 +309,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
     top = None
     if hasattr(args, 'monitor') and len(devices) > 0:
         try:
-            with libcurses(light_theme=args.light) as win:
+            with libcurses(colorful=args.colorful, light_theme=args.light) as win:
                 top = Top(
                     devices,
                     filters,

--- a/nvitop/cli.py
+++ b/nvitop/cli.py
@@ -52,10 +52,12 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
         version='%(prog)s {}'.format(__version__),
         help="Show %(prog)s's version number and exit.",
     )
-    parser.add_argument(
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         '--once', '-1', dest='once', action='store_true', help='Report query data only once.'
     )
-    parser.add_argument(
+    mode.add_argument(
         '--monitor',
         '-m',
         dest='monitor',
@@ -69,6 +71,7 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
             '(default fallback mode: auto)'
         ),
     )
+
     parser.add_argument(
         '--interval',
         dest='interval',
@@ -166,11 +169,25 @@ def parse_arguments():  # pylint: disable=too-many-branches,too-many-statements
         help="Only show GPU processes with the compute context. (type: 'C' or 'C+G')",
     )
     process_filtering.add_argument(
+        '--no-compute',
+        '-C',
+        dest='no_compute',
+        action='store_true',
+        help="Exclude GPU processes with the compute context. (type: 'G' only)",
+    )
+    process_filtering.add_argument(
         '--graphics',
         '-g',
         dest='graphics',
         action='store_true',
         help="Only show GPU processes with the graphics context. (type: 'G' or 'C+G')",
+    )
+    process_filtering.add_argument(
+        '--no-graphics',
+        '-G',
+        dest='no_graphics',
+        action='store_true',
+        help="Exclude GPU processes with the graphics context. (type: 'C' only)",
     )
     process_filtering.add_argument(
         '--user',
@@ -297,8 +314,12 @@ def main():  # pylint: disable=too-many-branches,too-many-statements,too-many-lo
     filters = []
     if args.compute:
         filters.append(lambda process: 'C' in process.type)
+    if args.no_compute:
+        filters.append(lambda process: 'C' not in process.type)
     if args.graphics:
         filters.append(lambda process: 'G' in process.type)
+    if args.no_graphics:
+        filters.append(lambda process: 'G' not in process.type)
     if args.user is not None:
         users = set(args.user)
         filters.append(lambda process: process.username in users)

--- a/nvitop/gui/library/history.py
+++ b/nvitop/gui/library/history.py
@@ -156,6 +156,8 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
         except ValueError:
             return NA
 
+    __str__ = last_value_string
+
     def max_value_string(self):
         max_value = self.max_value
         if max_value >= self.baseline:

--- a/nvitop/gui/screens/main/process.py
+++ b/nvitop/gui/screens/main/process.py
@@ -483,8 +483,7 @@ class ProcessPanel(Displayable):  # pylint: disable=too-many-instance-attributes
                     )
                 else:
                     if self.selected.is_same_on_host(process):
-                        self.addstr(y, self.x + 1, '=')
-                        self.color_at(y, self.x + 1, width=1, attr='bold | blink')
+                        self.addstr(y, self.x + 1, '=', self.get_fg_bg_attr(attr='bold | blink'))
                     self.color_at(y, self.x + 2, width=3, fg=color)
                     if str(process.username) != USERNAME and not SUPERUSER:
                         self.color_at(y, self.x + 5, width=self.width - 6, attr='dim')


### PR DESCRIPTION
#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.9.13`
- NVML version (driver version): `470.129.06`
- `nvitop` version or commit: `v0.7.1`
- `python-ml-py` version: `11.450.51`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

Use gradient colors for spectrum-like bar charts. This requires the user to set `TERM` to `*-256color` (e.g. `xterm-256color` or `tmux-256color`).

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Make `nvitop` more colorful.

#### Testing

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

N/A

#### Images / Videos  <!-- Only if relevant -->

<!-- Link or embed images and videos of screenshots, sketches etc. -->

![Spectrum](https://user-images.githubusercontent.com/16078332/182555606-8388e5a5-43a9-4990-90d4-46e45ac448a0.png)