### PR TITLE
feat(gui/metrics): add process metrics screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Install from PyPI ([![PyPI](https://img.shields.io/pypi/v/nvitop?label=PyPI)](ht
 pip3 install --upgrade nvitop
 ```
 
-Install the latest version from GitHub (![Commit Count](https://img.shields.io/github/commits-since/XuehaiPan/nvitop/v0.8.0)):
+Install the latest version from GitHub (![Commit Count](https://img.shields.io/github/commits-since/XuehaiPan/nvitop/v0.8.1)):
 
 ```bash
 pip3 install git+https://github.com/XuehaiPan/nvitop.git#egg=nvitop
@@ -244,15 +244,23 @@ $ nvitop --colorful
 
 You can configure the default monitor mode with the `NVITOP_MONITOR_MODE` environment variable (default `auto` if not set). See [Command Line Options and Environment Variables](#command-line-options-and-environment-variables) for more command options.
 
+In monitor mode, you can use <kbd>Ctrl-c</kbd> / <kbd>T</kbd> / <kbd>K</kbd> keys to interrupt / terminate / kill a process. And it's recommended to *terminate* or *kill* a process in the **tree-view screen** (shortcut: <kbd>t</kbd>). For normal users, `nvitop` will shallow other users' processes (in low-intensity colors). For **system administrators**, you can use `sudo nvitop` to terminate other users' processes.
+
+Also, to enter the process metrics screen, select a process and then press the <kbd>Enter</kbd> / <kbd>Return</kbd> key . `nvitop` dynamically displays the process metrics with live graphs.
+
+<p align="center">
+  <img width="100%" src="https://user-images.githubusercontent.com/16078332/192108815-37c03705-be44-47d4-9908-6d05175db230.png" alt="Process Metrics Screen">
+  </br>
+  Watch metrics for a specific process (shortcut: <kbd>Enter</kbd> / <kbd>Return</kbd>).
+</p>
+
 Press <kbd>h</kbd> for help or <kbd>q</kbd> to return to the terminal. See [Keybindings for Monitor Mode](#keybindings-for-monitor-mode) for more shortcuts.
 
 <p align="center">
-  <img width="100%" src="https://user-images.githubusercontent.com/16078332/188309362-eb35bdef-f740-45ff-9906-84662f3417ac.png" alt="Help Screen">
+  <img width="100%" src="https://user-images.githubusercontent.com/16078332/192108664-61f1983c-6f62-48e6-87c5-29633d9c409e.png" alt="Help Screen">
   </br>
   <code>nvitop</code> comes with a help screen (shortcut: <kbd>h</kbd>).
 </p>
-
-In monitor mode, you can use <kbd>Ctrl-c</kbd> / <kbd>T</kbd> / <kbd>K</kbd> keys to interrupt / terminate / kill a process. And it's recommended to *terminate* or *kill* a process in the **tree-view screen** (shortcut: <kbd>t</kbd>). For normal users, `nvitop` will shallow other users' processes (in low-intensity colors). For **system administrators**, you can use `sudo nvitop` to terminate other users' processes.
 
 #### For Docker Users
 
@@ -403,6 +411,7 @@ echo 'set -gx NVITOP_MONITOR_MODE "full"' >> ~/.config/fish/config.fish
 |                                                                            |                                                                                      |
 |                                                                        `e` | Show process environment.                                                            |
 |                                                                        `t` | Toggle tree-view screen.                                                             |
+|                                                                  `<Enter>` | Toggle tree-view screen.                                                             |
 |                                                                            |                                                                                      |
 |                                                                  `,` / `.` | Select the sort column.                                                              |
 |                                                                        `/` | Reverse the sort order.                                                              |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,7 +72,7 @@ Or, clone this repo and install manually:
 
 If this repo is useful to you, please star ⭐️ it to let more people know 🤗. |GitHub Repo Stars|_
 
-.. |Commit Count| image:: https://img.shields.io/github/commits-since/XuehaiPan/nvitop/v0.8.0
+.. |Commit Count| image:: https://img.shields.io/github/commits-since/XuehaiPan/nvitop/v0.8.1
 
 ------
 

--- a/nvitop/core/process.py
+++ b/nvitop/core/process.py
@@ -666,6 +666,8 @@ class GpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
     def update_gpu_status(self) -> Union[int, NaType]:
         """Updates the GPU consumption status from a new NVML query."""
 
+        self.set_gpu_memory(NA)
+        self.set_gpu_utilization(NA, NA, NA, NA)
         self.device.processes.cache_clear()
         self.device.processes()
         return self.gpu_memory()

--- a/nvitop/gui/library/__init__.py
+++ b/nvitop/gui/library/__init__.py
@@ -18,6 +18,7 @@ from nvitop.gui.library.keybinding import (
 from nvitop.gui.library.libcurses import libcurses, setlocale_utf8
 from nvitop.gui.library.mouse import MouseEvent
 from nvitop.gui.library.process import GpuProcess, HostProcess, Snapshot, bytes2human, host
+from nvitop.gui.library.selection import Selection
 from nvitop.gui.library.utils import (
     HOSTNAME,
     LARGE_INTEGER,

--- a/nvitop/gui/library/history.py
+++ b/nvitop/gui/library/history.py
@@ -56,6 +56,7 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
         width,
         height,
         format='{:.1f}'.format,  # pylint: disable=redefined-builtin
+        max_format=None,
         baseline=0.0,
         dynamic_bound=False,
         upsidedown=False,
@@ -63,6 +64,9 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
         assert baseline < upperbound
 
         self.format = format
+        if max_format is None:
+            max_format = format
+        self.max_format = max_format
 
         if dynamic_bound:
             min_bound = baseline + 0.25 * (upperbound - baseline)
@@ -140,6 +144,19 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
             self.remake_graph()
 
     @property
+    def graph_size(self):
+        return (self.width, self.height)
+
+    @graph_size.setter
+    def graph_size(self, value):
+        width, height = value
+        assert isinstance(width, int) and width >= 1
+        assert isinstance(height, int) and height >= 1
+        self._height = height
+        self._width = width - 1  # trigger force remake
+        self.width = width
+
+    @property
     def last_value(self):
         return self.reversed_history[0]
 
@@ -161,13 +178,15 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
     def max_value_string(self):
         max_value = self.max_value
         if max_value >= self.baseline:
-            return self.format(max_value)
+            return self.max_format(max_value)
         try:
-            return self.format(NA)
+            return self.max_format(NA)
         except ValueError:
             return NA
 
     def add(self, value):
+        if value is NA:
+            value = self.baseline - 0.1
         if not isinstance(value, (int, float)):
             return
 
@@ -263,6 +282,7 @@ class BufferedHistoryGraph(HistoryGraph):
         width,
         height,
         format='{:.1f}'.format,  # pylint: disable=redefined-builtin
+        max_format=None,
         baseline=0.0,
         dynamic_bound=False,
         upsidedown=False,
@@ -274,6 +294,7 @@ class BufferedHistoryGraph(HistoryGraph):
             width,
             height,
             format=format,
+            max_format=max_format,
             baseline=baseline,
             dynamic_bound=dynamic_bound,
             upsidedown=upsidedown,
@@ -292,6 +313,8 @@ class BufferedHistoryGraph(HistoryGraph):
         return last_value
 
     def add(self, value):
+        if value is NA:
+            value = self.baseline - 0.1
         if not isinstance(value, (int, float)):
             return
 

--- a/nvitop/gui/library/history.py
+++ b/nvitop/gui/library/history.py
@@ -40,6 +40,9 @@ PAIR2SYMBOL_DOWN = {
     (s1, s2): VALUE2SYMBOL_DOWN[(SYMBOL2VALUE_DOWN[s1][-1], SYMBOL2VALUE_DOWN[s2][0])]
     for s1, s2 in itertools.product(SYMBOL2VALUE_DOWN, repeat=2)
 }
+GRAPH_SYMBOLS = ''.join(
+    sorted(set(itertools.chain(VALUE2SYMBOL_UP.values(), VALUE2SYMBOL_DOWN.values())))
+).replace(' ', '')
 
 
 def grouped(iterable, size, fillvalue=None):

--- a/nvitop/gui/library/history.py
+++ b/nvitop/gui/library/history.py
@@ -59,6 +59,8 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
         max_format=None,
         baseline=0.0,
         dynamic_bound=False,
+        min_bound=None,
+        init_bound=None,
         upsidedown=False,
     ):
         assert baseline < upperbound
@@ -69,13 +71,18 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
         self.max_format = max_format
 
         if dynamic_bound:
-            min_bound = baseline + 0.25 * (upperbound - baseline)
+            if min_bound is None:
+                min_bound = baseline + 0.1 * (upperbound - baseline)
+            if init_bound is None:
+                init_bound = upperbound
         else:
-            min_bound = upperbound
+            assert min_bound is None
+            assert init_bound is None
+            min_bound = init_bound = upperbound
         self.baseline = baseline
         self.min_bound = min_bound
         self.max_bound = upperbound
-        self.bound = upperbound
+        self.bound = init_bound
         self.next_bound_update_at = time.monotonic()
         self._width = width
         self._height = height
@@ -286,6 +293,8 @@ class BufferedHistoryGraph(HistoryGraph):
         baseline=0.0,
         dynamic_bound=False,
         upsidedown=False,
+        min_bound=None,
+        init_bound=None,
         interval=1.0,
     ):
         assert interval > 0.0
@@ -297,6 +306,8 @@ class BufferedHistoryGraph(HistoryGraph):
             max_format=max_format,
             baseline=baseline,
             dynamic_bound=dynamic_bound,
+            min_bound=min_bound,
+            init_bound=init_bound,
             upsidedown=upsidedown,
         )
 

--- a/nvitop/gui/library/libcurses.py
+++ b/nvitop/gui/library/libcurses.py
@@ -10,6 +10,8 @@ import locale
 import os
 import signal
 
+from nvitop.gui.library.history import GRAPH_SYMBOLS
+
 
 LIGHT_THEME = False
 DEFAULT_FOREGROUND = curses.COLOR_WHITE
@@ -183,8 +185,8 @@ class CursesShortcuts:
     """
 
     ASCII_TRANSTABLE = str.maketrans(
-        '═' + '─╴' + '╒╤╕╪╘╧╛┌┬┐┼└┴┘' + '│╞╡├┤▏▎▍▌▋▊▉█░' + '▲▼' + '␤',
-        '=' + '--' + '++++++++++++++' + '||||||||||||||' + '^v' + '?',
+        '═' + '─╴' + '╒╤╕╪╘╧╛┌┬┐┼└┴┘' + '│╞╡├┤▏▎▍▌▋▊▉█░' + '▲▼' + '␤' + GRAPH_SYMBOLS,
+        '=' + '--' + '++++++++++++++' + '||||||||||||||' + '^v' + '?' + '=' * len(GRAPH_SYMBOLS),
     )
     TERM_256COLOR = False
 

--- a/nvitop/gui/library/process.py
+++ b/nvitop/gui/library/process.py
@@ -13,6 +13,17 @@ __all__ = ['host', 'HostProcess', 'GpuProcess', 'NA', 'Snapshot', 'bytes2human']
 
 
 class GpuProcess(GpuProcessBase):
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls, *args, **kwargs)
+        instance._snapshot = None
+        return instance
+
+    @property
+    def snapshot(self) -> Snapshot:
+        if self._snapshot is None:
+            self.as_snapshot()
+        return self._snapshot
+
     def host_snapshot(self) -> Snapshot:
         host_snapshot = super().host_snapshot()
 
@@ -38,12 +49,22 @@ class GpuProcess(GpuProcessBase):
         snapshot.cpu_percent_string = snapshot.host.cpu_percent_string
         snapshot.memory_percent_string = snapshot.host.memory_percent_string
 
+        if snapshot.is_running:
+            snapshot.is_zombie = snapshot.cmdline == ['Zombie Process']
+            snapshot.no_permissions = snapshot.cmdline == ['No Permissions']
+            snapshot.is_gone = False
+        else:
+            snapshot.is_zombie = False
+            snapshot.no_permissions = False
+            snapshot.is_gone = snapshot.cmdline == ['No Such Process']
+
         snapshot.gpu_memory_percent_string = self.gpu_memory_percent_string()
         snapshot.gpu_sm_utilization_string = self.gpu_sm_utilization_string()
         snapshot.gpu_memory_utilization_string = self.gpu_memory_utilization_string()
         snapshot.gpu_encoder_utilization_string = self.gpu_encoder_utilization_string()
         snapshot.gpu_decoder_utilization_string = self.gpu_decoder_utilization_string()
 
+        self._snapshot = snapshot  # pylint: disable=attribute-defined-outside-init
         return snapshot
 
     def gpu_memory_percent_string(self) -> str:  # in percentage

--- a/nvitop/gui/library/selection.py
+++ b/nvitop/gui/library/selection.py
@@ -5,13 +5,10 @@
 
 import signal
 import time
-from collections import namedtuple
 from weakref import WeakValueDictionary
 
-from nvitop.gui.library import LARGE_INTEGER, NA, SUPERUSER, USERNAME, Snapshot, host
-
-
-Order = namedtuple('Order', ['key', 'reverse', 'offset', 'column', 'previous', 'next'])
+from nvitop.core import NA, Snapshot, host
+from nvitop.gui.library.utils import LARGE_INTEGER, SUPERUSER, USERNAME
 
 
 class Selection:  # pylint: disable=too-many-instance-attributes

--- a/nvitop/gui/library/utils.py
+++ b/nvitop/gui/library/utils.py
@@ -21,9 +21,12 @@ def cut_string(s, maxlen, padstr='...', align='left'):
     if not isinstance(s, str):
         s = str(s)
     s = WideString(s)
+    padstr = WideString(padstr)
 
     if len(s) <= maxlen:
         return str(s)
+    if len(padstr) >= maxlen:
+        return str(padstr[:maxlen])
     if align == 'left':
         return str(s[: maxlen - len(padstr)] + padstr)
     return str(padstr + s[-(maxlen - len(padstr)) :])

--- a/nvitop/gui/screens/__init__.py
+++ b/nvitop/gui/screens/__init__.py
@@ -6,4 +6,5 @@
 from nvitop.gui.screens.environ import EnvironScreen
 from nvitop.gui.screens.help import HelpScreen
 from nvitop.gui.screens.main import BreakLoop, MainScreen
+from nvitop.gui.screens.metrics import ProcessMetricsScreen
 from nvitop.gui.screens.treeview import TreeViewScreen

--- a/nvitop/gui/screens/environ.py
+++ b/nvitop/gui/screens/environ.py
@@ -139,6 +139,8 @@ class EnvironScreen(Displayable):  # pylint: disable=too-many-instance-attribute
         self.width = n_term_cols - self.x
         self.height = n_term_lines - self.y
 
+        return termsize
+
     def draw(self):
         self.color_reset()
 

--- a/nvitop/gui/screens/help.py
+++ b/nvitop/gui/screens/help.py
@@ -22,10 +22,11 @@ Device coloring rules by loading intensity:
      Arrows: scroll process list              Space: tag/untag current process
        Home: select the first process           Esc: clear process selection
         End: select the last process       Ctrl-C I: interrupt selected process
-   Ctrl-A ^: scroll to left most                  K: kill selected process
-   Ctrl-E $: scroll to right most                 T: terminate selected process
-   PageUp [: scroll entire screen up              e: show process environment
- PageDown ]: scroll entire screen down            t: toggle tree-view screen
+                                                  K: kill selected process
+   Ctrl-A ^: scroll to left most                  T: terminate selected process
+   Ctrl-E $: scroll to right most                 e: show process environment
+   PageUp [: scroll entire screen up              t: toggle tree-view screen
+ PageDown ]: scroll entire screen down        Enter: show process metrics
 
       Wheel: scroll process list        Shift-Wheel: scroll horizontally
         Tab: scroll process list         Ctrl-Wheel: fast scroll ({}x)
@@ -57,16 +58,17 @@ class HelpScreen(Displayable):  # pylint: disable=too-many-instance-attributes
             .splitlines()
         )
         self.color_matrix = {
-            **{dy: ('cyan', 'cyan') for dy in range(12, 22)},
             9: ('green', 'green'),
             10: ('green', 'green'),
             12: ('cyan', 'yellow'),
             13: ('cyan', 'yellow'),
-            **{dy: ('cyan', 'red') for dy in (14, 15, 16)},
-            19: (None, None),
-            22: (None, None),
-            **{dy: ('blue', 'blue') for dy in range(23, 27)},
-            27: ('magenta', 'magenta'),
+            14: ('cyan', 'red'),
+            15: (None, 'red'),
+            16: ('cyan', 'red'),
+            **{dy: ('cyan', 'green') for dy in range(17, 20)},
+            **{dy: ('blue', 'blue') for dy in range(21, 23)},
+            **{dy: ('blue', 'blue') for dy in range(24, 28)},
+            28: ('magenta', 'magenta'),
         }
 
         self.x, self.y = root.x, root.y

--- a/nvitop/gui/screens/main/__init__.py
+++ b/nvitop/gui/screens/main/__init__.py
@@ -120,6 +120,8 @@ class MainScreen(DisplayableContainer):  # pylint: disable=too-many-instance-att
             self.height = height
             self.need_redraw = True
 
+        return termsize
+
     def move(self, direction=0):
         if direction == 0:
             return

--- a/nvitop/gui/screens/main/host.py
+++ b/nvitop/gui/screens/main/host.py
@@ -281,6 +281,7 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
                     (20, '╴30s├'),
                     (35, '╴60s├'),
                     (66, '╴120s├'),
+                    (96, '╴180s├'),
                     (126, '╴240s├'),
                 ):
                     if offset > remaining_width:

--- a/nvitop/gui/screens/main/host.py
+++ b/nvitop/gui/screens/main/host.py
@@ -111,9 +111,7 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
         )(host.swap_percent)
 
         def percentage(x):
-            if x is NA:
-                return NA
-            return '{:.1f}%'.format(x)
+            return '{:.1f}%'.format(x) if x is not NA else NA
 
         def enable_history(device):
             device.memory_percent = BufferedHistoryGraph(
@@ -153,7 +151,7 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
         )
         self.average_gpu_utilization = BufferedHistoryGraph(
             interval=1.0,
-            width=32,
+            width=20,
             height=5,
             upsidedown=True,
             baseline=0.0,

--- a/nvitop/gui/screens/main/host.py
+++ b/nvitop/gui/screens/main/host.py
@@ -283,6 +283,7 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
                     (66, '╴120s├'),
                     (96, '╴180s├'),
                     (126, '╴240s├'),
+                    (156, '╴300s├'),
                 ):
                     if offset > remaining_width:
                         break

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -1,0 +1,429 @@
+# This file is part of nvitop, the interactive NVIDIA-GPU process viewer.
+# License: GNU GPL version 3.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+import threading
+import time
+from collections import OrderedDict
+
+from nvitop.gui.library import (
+    HOSTNAME,
+    NA,
+    SUPERUSER,
+    USERCONTEXT,
+    USERNAME,
+    BufferedHistoryGraph,
+    Displayable,
+    GpuProcess,
+    Selection,
+    WideString,
+    bytes2human,
+    cut_string,
+    host,
+    wcslen,
+)
+
+
+class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-attributes
+    NAME = 'process-metrics'
+    SNAPSHOT_INTERVAL = 0.5
+
+    def __init__(self, win, root):
+        super().__init__(win, root)
+
+        self.selection = Selection(panel=self)
+        self.used_gpu_memory = None
+        self.gpu_sm_utilization = None
+        self.cpu_percent = None
+        self.used_host_memory = None
+
+        self.enabled = False
+        self.snapshot_lock = threading.Lock()
+        self._snapshot_daemon = threading.Thread(
+            name='process-metrics-snapshot-daemon', target=self._snapshot_target, daemon=True
+        )
+        self._daemon_running = threading.Event()
+
+        self.x, self.y = root.x, root.y
+        self.width, self.height = root.width, root.height
+        self.left_width = max(20, (self.width - 3) // 2)
+        self.right_width = max(20, (self.width - 2) // 2)
+        self.upper_height = max(5, (self.height - 5 - 3) // 2)
+        self.lower_height = max(5, (self.height - 5 - 2) // 2)
+
+    @property
+    def visible(self):
+        return self._visible
+
+    @visible.setter
+    def visible(self, value):
+        if self._visible != value:
+            self.need_redraw = True
+            self._visible = value
+        if self.visible:
+            self._daemon_running.set()
+            try:
+                self._snapshot_daemon.start()
+            except RuntimeError:
+                pass
+            self.take_snapshots()
+        else:
+            self.disable()
+            self.focused = False
+
+    def enable(self, state=True):
+        if not self.selection.is_set() or not state:
+            self.disable()
+            return
+
+        total_host_memory = host.virtual_memory().total
+        total_host_memory_human = bytes2human(total_host_memory)
+        total_gpu_memory = self.process.device.memory_total()
+        total_gpu_memory_human = bytes2human(total_gpu_memory)
+
+        def format_cpu_percent(value):
+            if value is NA:
+                return 'CPU: {}'.format(value)
+            return 'CPU: {:.1f}%'.format(value)
+
+        def format_max_cpu_percent(value):
+            if value is NA:
+                return 'MAX CPU: {}'.format(value)
+            return 'MAX CPU: {:.1f}%'.format(value)
+
+        def format_host_memory(value):
+            if value is NA:
+                return 'HOST-MEM: {}'.format(value)
+            return 'HOST-MEM: {} ({:.1f}%)'.format(
+                bytes2human(value),
+                round(100.0 * value / total_host_memory, 1),
+            )
+
+        def format_max_host_memory(value):
+            if value is NA:
+                return 'MAX HOST-MEM: {}'.format(value)
+            return 'MAX HOST-MEM: {} ({:.1f}%) / {}'.format(
+                bytes2human(value),
+                round(100.0 * value / total_host_memory, 1),
+                total_host_memory_human,
+            )
+
+        def format_gpu_memory(value):
+            if value is not NA and total_gpu_memory is not NA:
+                return 'GPU-MEM: {} ({:.1f}%)'.format(
+                    bytes2human(value),
+                    round(100.0 * value / total_gpu_memory, 1),
+                )
+            return 'GPU-MEM: {}'.format(value)
+
+        def format_max_gpu_memory(value):
+            if value is not NA and total_gpu_memory is not NA:
+                return 'MAX GPU-MEM: {} ({:.1f}%) / {}'.format(
+                    bytes2human(value),
+                    round(100.0 * value / total_gpu_memory, 1),
+                    total_gpu_memory_human,
+                )
+            return 'MAX GPU-MEM: {}'.format(value)
+
+        def format_sm(value):
+            if value is NA:
+                return 'GPU-SM: {}'.format(value)
+            return 'GPU-SM: {:.1f}%'.format(value)
+
+        def format_max_sm(value):
+            if value is NA:
+                return 'MAX GPU-SM: {}'.format(value)
+            return 'MAX GPU-SM: {:.1f}%'.format(value)
+
+        with self.snapshot_lock:
+            self.cpu_percent = BufferedHistoryGraph(
+                interval=1.0,
+                upperbound=100.0,
+                width=self.left_width,
+                height=self.upper_height,
+                baseline=0.0,
+                upsidedown=False,
+                dynamic_bound=True,
+                format=format_cpu_percent,
+                max_format=format_max_cpu_percent,
+            )
+            self.used_host_memory = BufferedHistoryGraph(
+                interval=1.0,
+                upperbound=total_host_memory,
+                width=self.left_width,
+                height=self.lower_height,
+                baseline=0.0,
+                upsidedown=True,
+                format=format_host_memory,
+                max_format=format_max_host_memory,
+            )
+            self.used_gpu_memory = BufferedHistoryGraph(
+                interval=1.0,
+                upperbound=total_gpu_memory or 1,
+                width=self.right_width,
+                height=self.upper_height,
+                baseline=0.0,
+                upsidedown=False,
+                dynamic_bound=True,
+                format=format_gpu_memory,
+                max_format=format_max_gpu_memory,
+            )
+            self.gpu_sm_utilization = BufferedHistoryGraph(
+                interval=1.0,
+                upperbound=100.0,
+                width=self.right_width,
+                height=self.lower_height,
+                baseline=0.0,
+                upsidedown=True,
+                format=format_sm,
+                max_format=format_max_sm,
+            )
+
+            self._daemon_running.set()
+            try:
+                self._snapshot_daemon.start()
+            except RuntimeError:
+                pass
+            self.enabled = True
+
+        self.take_snapshots()
+        self.update_size()
+
+    def disable(self):
+        with self.snapshot_lock:
+            self._daemon_running.clear()
+            self.enabled = False
+            self.cpu_percent = None
+            self.used_host_memory = None
+            self.used_gpu_memory = None
+            self.gpu_sm_utilization = None
+
+    @property
+    def process(self):
+        return self.selection.process
+
+    @process.setter
+    def process(self, value):
+        self.selection.process = value
+        self.enable()
+
+    def take_snapshots(self):
+        with self.snapshot_lock:
+            if not self.selection.is_set() or not self.enabled:
+                return
+
+            with GpuProcess.failsafe():
+                self.process.device.as_snapshot()
+                self.process.update_gpu_status()
+                snapshot = self.process.as_snapshot()
+
+                self.cpu_percent.add(snapshot.cpu_percent)
+                self.used_host_memory.add(snapshot.host_memory)
+                self.used_gpu_memory.add(snapshot.gpu_memory)
+                self.gpu_sm_utilization.add(snapshot.gpu_sm_utilization)
+
+    def _snapshot_target(self):
+        while True:
+            self._daemon_running.wait()
+            self.take_snapshots()
+            time.sleep(self.SNAPSHOT_INTERVAL)
+
+    def update_size(self, termsize=None):
+        n_term_lines, n_term_cols = termsize = super().update_size(termsize=termsize)
+
+        self.width = n_term_cols - self.x
+        self.height = n_term_lines - self.y
+        self.left_width = max(20, (self.width - 3) // 2)
+        self.right_width = max(20, (self.width - 2) // 2)
+        self.upper_height = max(5, (self.height - 8) // 2)
+        self.lower_height = max(5, (self.height - 7) // 2)
+        self.need_redraw = True
+
+        with self.snapshot_lock:
+            if self.enabled:
+                self.cpu_percent.graph_size = (self.left_width, self.upper_height)
+                self.used_host_memory.graph_size = (self.left_width, self.lower_height)
+                self.used_gpu_memory.graph_size = (self.right_width, self.upper_height)
+                self.gpu_sm_utilization.graph_size = (self.right_width, self.lower_height)
+
+    def frame_lines(self):
+        line = '│' + ' ' * self.left_width + '│' + ' ' * self.right_width + '│'
+        frame = [
+            '╒' + '═' * (self.width - 2) + '╕',
+            '│ {} │'.format('Process:'.ljust(self.width - 4)),
+            '│ {} │'.format('GPU'.ljust(self.width - 4)),
+            '╞' + '═' * (self.width - 2) + '╡',
+            '│' + ' ' * (self.width - 2) + '│',
+            '╞' + '═' * self.left_width + '╤' + '═' * self.right_width + '╡',
+            *([line] * self.upper_height),
+            '├' + '─' * self.left_width + '┼' + '─' * self.right_width + '┤',
+            *([line] * self.lower_height),
+            '╘' + '═' * self.left_width + '╧' + '═' * self.right_width + '╛',
+        ]
+        return frame
+
+    def poke(self):
+        if self.visible and not self._daemon_running.is_set():
+            self._daemon_running.set()
+            try:
+                self._snapshot_daemon.start()
+            except RuntimeError:
+                pass
+            self.take_snapshots()
+
+        super().poke()
+
+    def draw(self):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
+        self.color_reset()
+
+        if self.need_redraw:
+            for y, line in enumerate(self.frame_lines(), start=self.y):
+                self.addstr(y, self.x, line)
+
+            context_width = wcslen(USERCONTEXT)
+            if not host.WINDOWS or len(USERCONTEXT) == context_width:
+                # Do not support windows-curses with wide characters
+                username_width = wcslen(USERNAME)
+                hostname_width = wcslen(HOSTNAME)
+                offset = self.x + self.width - context_width - 2
+                self.addstr(self.y + 1, self.x + offset, USERCONTEXT)
+                self.color_at(self.y + 1, self.x + offset, width=context_width, attr='bold')
+                self.color_at(
+                    self.y + 1,
+                    self.x + offset,
+                    width=username_width,
+                    fg=('yellow' if SUPERUSER else 'magenta'),
+                    attr='bold',
+                )
+                self.color_at(
+                    self.y + 1,
+                    self.x + offset + username_width + 1,
+                    width=hostname_width,
+                    fg='green',
+                    attr='bold',
+                )
+
+            for offset, string in (
+                (19, '╴30s├'),
+                (34, '╴60s├'),
+                (65, '╴120s├'),
+                (125, '╴240s├'),
+            ):
+                for x_offset, width in (
+                    (self.x + 1 + self.left_width, self.left_width),
+                    (self.x + 1 + self.left_width + 1 + self.right_width, self.right_width),
+                ):
+                    if offset > width:
+                        break
+                    self.addstr(self.y + self.upper_height + 6, x_offset - offset, string)
+                    self.color_at(
+                        self.y + self.upper_height + 6,
+                        x_offset - offset + 1,
+                        width=len(string) - 2,
+                        attr='dim',
+                    )
+
+        self.color(fg='cyan')
+        for y, line in enumerate(self.cpu_percent.graph, start=self.y + 6):
+            self.addstr(y, self.x + 1, line)
+
+        self.color(fg='magenta')
+        for y, line in enumerate(self.used_host_memory.graph, start=self.y + self.upper_height + 7):
+            self.addstr(y, self.x + 1, line)
+
+        self.color(fg='blue')
+        for y, line in enumerate(self.used_gpu_memory.graph, start=self.y + 6):
+            self.addstr(y, self.x + self.left_width + 2, line)
+
+        self.color(fg='red')
+        for y, line in enumerate(
+            self.gpu_sm_utilization.graph, start=self.y + self.upper_height + 7
+        ):
+            self.addstr(y, self.x + self.left_width + 2, line)
+
+        self.color_reset()
+        self.addstr(self.y + 6, self.x + 1, ' {} '.format(self.cpu_percent.max_value_string()))
+        self.addstr(self.y + 7, self.x + 5, ' {} '.format(self.cpu_percent))
+        self.addstr(
+            self.y + self.upper_height + self.lower_height + 5,
+            self.x + 5,
+            ' {} '.format(self.used_host_memory),
+        )
+        self.addstr(
+            self.y + self.upper_height + self.lower_height + 6,
+            self.x + 1,
+            ' {} '.format(self.used_host_memory.max_value_string()),
+        )
+        self.addstr(
+            self.y + 6,
+            self.x + self.left_width + 2,
+            ' {} '.format(self.used_gpu_memory.max_value_string()),
+        )
+        self.addstr(self.y + 7, self.x + self.left_width + 6, ' {} '.format(self.used_gpu_memory))
+        self.addstr(
+            self.y + self.upper_height + self.lower_height + 5,
+            self.x + self.left_width + 6,
+            ' {} '.format(self.gpu_sm_utilization),
+        )
+        self.addstr(
+            self.y + self.upper_height + self.lower_height + 6,
+            self.x + self.left_width + 2,
+            ' {} '.format(self.gpu_sm_utilization.max_value_string()),
+        )
+
+        process = self.process.snapshot
+        columns = OrderedDict(
+            [
+                ('PID', str(process.pid).rjust(3)),
+                ('USER', WideString('{} {}'.format(process.type, process.username).rjust(6))),
+                (' GPU-MEM', process.gpu_memory_human.rjust(8)),
+                (' %SM', str(process.gpu_sm_utilization).rjust(4)),
+                ('%GMBW', str(process.gpu_memory_utilization).rjust(5)),
+                ('%ENC', str(process.gpu_encoder_utilization).rjust(4)),
+                ('%DEC', str(process.gpu_encoder_utilization).rjust(4)),
+                ('  %CPU', process.cpu_percent_string.rjust(6)),
+                (' %MEM', process.memory_percent_string.rjust(5)),
+                (' TIME', (' ' + process.running_time_human).rjust(5)),
+            ]
+        )
+
+        self.addstr(self.y + 4, self.x + 1, '{:>4} '.format(self.process.device.display_index))
+        self.color_at(
+            self.y + 4, self.x + 1, width=4, fg=self.process.device.snapshot.display_color
+        )
+        x = self.x + 7
+        for col, value in columns.items():
+            width = len(value)
+            self.addstr(self.y + 2, x, col.rjust(width))
+            self.addstr(self.y + 4, x, str(value + '  '))
+            x += width + 1
+
+        x += 1
+        if x + 4 < self.width - 2:
+            self.addstr(
+                self.y + 2,
+                x,
+                cut_string('COMMAND', self.width - x - 2, padstr='..').ljust(self.width - x - 2),
+            )
+            if process.is_zombie or process.no_permissions:
+                self.color(fg='yellow')
+            elif process.is_gone:
+                self.color(fg='red')
+            self.addstr(
+                self.y + 4,
+                x,
+                cut_string(
+                    WideString(process.command).ljust(self.width - x - 2),
+                    self.width - x - 2,
+                    padstr='..',
+                ),
+            )
+
+    def destroy(self):
+        super().destroy()
+        self._daemon_running.clear()
+
+    def press(self, key):
+        self.root.keymaps.use_keymap('process-metrics')
+        self.root.press(key)

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -486,6 +486,8 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                     self.addstr(y, self.x + self.left_width + 2, line)
 
             self.color_reset()
+            self.addstr(self.y + 2, self.x + self.width - 2, ' │')  # handle overflow
+            self.addstr(self.y + 4, self.x + self.width - 2, ' │')  # handle overflow
             self.addstr(self.y + 6, self.x + 1, ' {} '.format(self.cpu_percent.max_value_string()))
             self.addstr(self.y + 7, self.x + 5, ' {} '.format(self.cpu_percent))
             self.addstr(

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -154,6 +154,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                 height=self.lower_height,
                 baseline=0.0,
                 upsidedown=True,
+                dynamic_bound=True,
                 format=format_host_memory,
                 max_format=format_max_host_memory,
             )
@@ -175,6 +176,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                 height=self.lower_height,
                 baseline=0.0,
                 upsidedown=True,
+                dynamic_bound=True,
                 format=format_sm,
                 max_format=format_max_sm,
             )

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -69,7 +69,6 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                 pass
             self.take_snapshots()
         else:
-            self.disable()
             self.focused = False
 
     def enable(self, state=True):

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -369,6 +369,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                 (65, '╴120s├'),
                 (95, '╴180s├'),
                 (125, '╴240s├'),
+                (155, '╴300s├'),
             ):
                 for x_offset, width in (
                     (self.x + 1 + self.left_width, self.left_width),

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -306,6 +306,8 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
                 self.used_gpu_memory.graph_size = (self.right_width, self.upper_height)
                 self.gpu_sm_utilization.graph_size = (self.right_width, self.lower_height)
 
+        return termsize
+
     def frame_lines(self):
         line = '│' + ' ' * self.left_width + '│' + ' ' * self.right_width + '│'
         frame = [

--- a/nvitop/gui/screens/metrics.py
+++ b/nvitop/gui/screens/metrics.py
@@ -332,15 +332,34 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
         for y, line in enumerate(self.used_host_memory.graph, start=self.y + self.upper_height + 7):
             self.addstr(y, self.x + 1, line)
 
-        self.color(fg='blue')
-        for y, line in enumerate(self.used_gpu_memory.graph, start=self.y + 6):
-            self.addstr(y, self.x + self.left_width + 2, line)
+        if self.TERM_256COLOR:
+            for i, (y, line) in enumerate(enumerate(self.used_gpu_memory.graph, start=self.y + 6)):
+                self.addstr(
+                    y,
+                    self.x + self.left_width + 2,
+                    line,
+                    self.get_fg_bg_attr(fg=1.0 - i / (self.upper_height - 1)),
+                )
 
-        self.color(fg='red')
-        for y, line in enumerate(
-            self.gpu_sm_utilization.graph, start=self.y + self.upper_height + 7
-        ):
-            self.addstr(y, self.x + self.left_width + 2, line)
+            for i, (y, line) in enumerate(
+                enumerate(self.gpu_sm_utilization.graph, start=self.y + self.upper_height + 7)
+            ):
+                self.addstr(
+                    y,
+                    self.x + self.left_width + 2,
+                    line,
+                    self.get_fg_bg_attr(fg=i / (self.lower_height - 1)),
+                )
+        else:
+            self.color(fg=self.process.device.snapshot.memory_display_color)
+            for y, line in enumerate(self.used_gpu_memory.graph, start=self.y + 6):
+                self.addstr(y, self.x + self.left_width + 2, line)
+
+            self.color(fg=self.process.device.snapshot.gpu_display_color)
+            for y, line in enumerate(
+                self.gpu_sm_utilization.graph, start=self.y + self.upper_height + 7
+            ):
+                self.addstr(y, self.x + self.left_width + 2, line)
 
         self.color_reset()
         self.addstr(self.y + 6, self.x + 1, ' {} '.format(self.cpu_percent.max_value_string()))

--- a/nvitop/gui/screens/treeview.py
+++ b/nvitop/gui/screens/treeview.py
@@ -17,11 +17,11 @@ from nvitop.gui.library import (
     USERNAME,
     Displayable,
     HostProcess,
+    Selection,
     Snapshot,
     WideString,
     host,
 )
-from nvitop.gui.screens.main.utils import Selection
 
 
 class TreeNode:  # pylint: disable=too-many-instance-attributes

--- a/nvitop/gui/screens/treeview.py
+++ b/nvitop/gui/screens/treeview.py
@@ -329,6 +329,8 @@ class TreeViewScreen(Displayable):  # pylint: disable=too-many-instance-attribut
         self.width = n_term_cols - self.x
         self.height = n_term_lines - self.y
 
+        return termsize
+
     def poke(self):
         if self._daemon_running.is_set():
             self.snapshots = self._snapshot_buffer

--- a/nvitop/gui/top.py
+++ b/nvitop/gui/top.py
@@ -92,6 +92,8 @@ class Top(DisplayableContainer):  # pylint: disable=too-many-instance-attributes
             self.termsize = termsize
             self.need_redraw = True
 
+        return termsize
+
     def poke(self):
         super().poke()
 

--- a/nvitop/gui/top.py
+++ b/nvitop/gui/top.py
@@ -283,9 +283,10 @@ class Top(DisplayableContainer):  # pylint: disable=too-many-instance-attributes
             self.main_screen.selection.clear()
 
         def show_process_metrics():
-            if self.current_screen is self.main_screen and self.main_screen.selection.is_set():
-                show_screen(self.process_metrics_screen, focused=True)
-                self.process_metrics_screen.process = self.previous_screen.selection.process
+            if self.current_screen is self.main_screen:
+                if self.main_screen.selection.is_set():
+                    show_screen(self.process_metrics_screen, focused=True)
+                    self.process_metrics_screen.process = self.previous_screen.selection.process
             elif self.current_screen is not self.treeview_screen:
                 show_screen(self.process_metrics_screen, focused=True)
 

--- a/nvitop/gui/top.py
+++ b/nvitop/gui/top.py
@@ -256,15 +256,19 @@ class Top(DisplayableContainer):  # pylint: disable=too-many-instance-attributes
             if self.treeview_screen.selection.is_set():
                 self.main_screen.selection.process = self.treeview_screen.selection.process
             self.treeview_screen.selection.clear()
+            self.process_metrics_screen.disable()
 
         def show_environ():
             show_screen(self.environ_screen, focused=True)
 
-            self.environ_screen.process = self.previous_screen.selection.process
+            if self.previous_screen is not self.help_screen:
+                self.environ_screen.process = self.previous_screen.selection.process
 
         def environ_return():
             if self.previous_screen is self.treeview_screen:
                 show_treeview()
+            elif self.previous_screen is self.process_metrics_screen:
+                show_process_metrics()
             else:
                 show_main()
 
@@ -281,8 +285,9 @@ class Top(DisplayableContainer):  # pylint: disable=too-many-instance-attributes
         def show_process_metrics():
             if self.current_screen is self.main_screen and self.main_screen.selection.is_set():
                 show_screen(self.process_metrics_screen, focused=True)
-
                 self.process_metrics_screen.process = self.previous_screen.selection.process
+            elif self.current_screen is not self.treeview_screen:
+                show_screen(self.process_metrics_screen, focused=True)
 
         def show_help():
             show_screen(self.help_screen, focused=True)
@@ -292,6 +297,8 @@ class Top(DisplayableContainer):  # pylint: disable=too-many-instance-attributes
                 show_treeview()
             elif self.previous_screen is self.environ_screen:
                 show_environ()
+            elif self.previous_screen is self.process_metrics_screen:
+                show_process_metrics()
             else:
                 show_main()
 


### PR DESCRIPTION
#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.9.13`
- NVML version (driver version): `470.129.06`
- `nvitop` version or commit: `main`
- `python-ml-py` version: `11.450.51`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

Add process metrics screen. Watch metrics for a specific process in the terminal.

In addition to metrics (`GPU-MEM`, `%SM`, `%CPU`, `%MEM`, `TIME`) already on the main screen, it adds:

- live graph for `%CPU` and metric for max `%CPU`
- live graph for `HOST-MEM` and `%MEM`, and metric for max `HOST-MEM`
- live graph for `GPU-MEM` and `%GPU-MEM`, and metric for max `GPU-MEM`
- live graph for `%SM` and metric for max `%SM`
- metric `%GMBW`: GPU memory bandwidth utilization
- metric `%ENC`: encoder utilization
- metric `%DEC`: decoder utilization

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Resolves #36

#### Testing

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### Images / Videos  <!-- Only if relevant -->

<!-- Link or embed images and videos of screenshots, sketches etc. -->

<p align="center">
  <img width="100%" src="https://user-images.githubusercontent.com/16078332/192108815-37c03705-be44-47d4-9908-6d05175db230.png" alt="Process Metrics Screen">
  </br>
  Watch metrics for a specific process (shortcut: <kbd>Enter</kbd> / <kbd>Return</kbd>).
</p>