### PR TITLE
feat(core/collector): add function and method to collect metrics in background thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ df.to_csv('results.csv', index=False)
 You can also daemonize the collector in background using [`collect_in_background`](https://nvitop.readthedocs.io/en/latest/core/collector.html#nvitop.collect_in_background) with callback functions.
 
 ```python
-from nvitop import Device, collect_in_background
+from nvitop import Device, ResourceMetricCollector, collect_in_background
 
 logger = ...
 
@@ -920,6 +920,16 @@ def on_stop(collector):  # will be called only once at stop
 collect_in_background(
     on_collect,
     ResourceMetricCollector(Device.cuda.all()),
+    interval=5.0,
+    on_stop=on_stop,
+)
+```
+
+or simply:
+
+```python
+ResourceMetricCollector(Device.cuda.all()).daemonize(
+    on_collect,
     interval=5.0,
     on_stop=on_stop,
 )

--- a/README.md
+++ b/README.md
@@ -898,6 +898,33 @@ df.insert(0, 'time', df['resources/timestamp'].map(datetime.datetime.fromtimesta
 df.to_csv('results.csv', index=False)
 ```
 
+You can also daemonize the collector in background using [`collect_in_background`](https://nvitop.readthedocs.io/en/latest/core/collector.html#nvitop.collect_in_background) with callback functions.
+
+```python
+from nvitop import Device, collect_in_background
+
+logger = ...
+
+def on_collect(metrics):  # will be called periodically
+    if logger.is_closed():  # closed manually by user
+        return False
+    logger.log(metrics)
+    return True
+
+def on_stop(collector):  # will be called only once at stop
+    if not logger.is_closed():
+        logger.close()  # cleanup
+
+# Record metrics to the logger in background every 5 seconds.
+# It will collect 5-second mean/min/max for each metric.
+collect_in_background(
+    on_collect,
+    ResourceMetricCollector(Device.cuda.all()),
+    interval=5.0,
+    on_stop=on_stop,
+)
+```
+
 ------
 
 #### Low-level APIs

--- a/README.md
+++ b/README.md
@@ -898,7 +898,7 @@ df.insert(0, 'time', df['resources/timestamp'].map(datetime.datetime.fromtimesta
 df.to_csv('results.csv', index=False)
 ```
 
-You can also daemonize the collector in background using [`collect_in_background`](https://nvitop.readthedocs.io/en/latest/core/collector.html#nvitop.collect_in_background) with callback functions.
+You can also daemonize the collector in background using [`collect_in_background`](https://nvitop.readthedocs.io/en/latest/core/collector.html#nvitop.collect_in_background) or [`ResourceMetricCollector.daemonize`](https://nvitop.readthedocs.io/en/latest/core/collector.html#nvitop.ResourceMetricCollector.daemonize) with callback functions.
 
 ```python
 from nvitop import Device, ResourceMetricCollector, collect_in_background

--- a/docs/source/core/collector.rst
+++ b/docs/source/core/collector.rst
@@ -6,12 +6,15 @@ nvitop.collector module
 .. autosummary::
 
     take_snapshots
+    collect_in_background
     ResourceMetricCollector
 
 .. automodule:: nvitop.collector
     :no-members:
 
 .. autofunction:: nvitop.take_snapshots
+
+.. autofunction:: nvitop.collect_in_background
 
 .. autoclass:: nvitop.ResourceMetricCollector
     :members:

--- a/docs/source/core/collector.rst
+++ b/docs/source/core/collector.rst
@@ -8,6 +8,7 @@ nvitop.collector module
     take_snapshots
     collect_in_background
     ResourceMetricCollector
+    ResourceMetricCollector.daemonize
 
 .. automodule:: nvitop.collector
     :no-members:

--- a/nvitop/core/__init__.py
+++ b/nvitop/core/__init__.py
@@ -4,7 +4,7 @@
 """The core APIs of nvitop."""
 
 from nvitop.core import host, libcuda, libnvml, utils
-from nvitop.core.collector import ResourceMetricCollector, take_snapshots
+from nvitop.core.collector import ResourceMetricCollector, collect_in_background, take_snapshots
 from nvitop.core.device import (
     CudaDevice,
     CudaMigDevice,
@@ -21,6 +21,7 @@ from nvitop.core.utils import *
 
 __all__ = [
     'take_snapshots',
+    'collect_in_background',
     'ResourceMetricCollector',
     'libnvml',
     'nvmlCheckReturn',

--- a/nvitop/core/collector.py
+++ b/nvitop/core/collector.py
@@ -168,11 +168,11 @@ def take_snapshots(
     return SnapshotResult(devices, gpu_processes)
 
 
+# pylint: disable-next=too-many-arguments
 def collect_in_background(
     on_collect: Callable[[Dict[str, float]], bool],
     collector: Optional['ResourceMetricCollector'] = None,
     interval: Optional[float] = None,
-    *,
     on_start: Optional[Callable[['ResourceMetricCollector'], None]] = None,
     on_stop: Optional[Callable[['ResourceMetricCollector'], None]] = None,
     tag: str = 'metrics-daemon',

--- a/nvitop/core/collector.py
+++ b/nvitop/core/collector.py
@@ -180,6 +180,8 @@ def collect_in_background(
 ) -> threading.Thread:
     """Starts a background daemon thread that collect and call the callback function periodically.
 
+    See also :func:`ResourceMetricCollector.daemonize`.
+
     Args:
         on_collect: (Callable[[Dict[str, float]], bool])
             A callback function that will be called periodically. It takes a dictionary containing
@@ -592,6 +594,8 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
         start: bool = True,
     ) -> threading.Thread:
         """Starts a background daemon thread that collect and call the callback function periodically.
+
+        See also :func:`collect_in_background`.
 
         Args:
             on_collect: (Callable[[Dict[str, float]], bool])


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.9.13`
- NVML version (driver version): `470.129.06`
- `nvitop` version or commit: `v0.10.1`
- `python-ml-py` version: `11.515.75`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

Add a function to create a background daemon for metrics collectors.

A minimal example:

```python
from nvitop import collect_in_background

def on_collect(metrics):
    print(metrics)
    return True

collect_in_background(on_collect)  # print metrics to stdout every 1 second
```

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Resolves #47
