### PR TITLE
[update] Fix build problem of 'Dockerfile'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-ARG basetag="418.87.01-ubuntu18.04"  # Ubuntu only
+# Ubuntu only
+ARG basetag="418.87.01-ubuntu18.04"  
+
 FROM nvidia/driver:"${basetag}"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -18,6 +20,11 @@ RUN apt-get update && \
 # Setup locale
 ENV LC_ALL=C.UTF-8
 RUN update-locale LC_ALL="C.UTF-8"
+
+# Install dependencies
+RUN python3 -m pip install --upgrade pip
+COPY ./requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt
 
 # Install nvitop
 COPY . /nvitop


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS / Ubuntu 18.04 LTS
- Terminal emulator and version: XTerm
- Python version: `3.6` (inside Docker)
- NVML version (driver version): [e.g. `515.86` / `440.44`]
- `nvitop` version or commit: `0.11.0`
- `python-ml-py` version: -
- Locale: -

#### Description

<!-- Describe the changes in detail -->

Adding following changes to `Dockerfile` to resolve the problem in running `nvitop` command in a Docker container.
- Copying `requirements.txt` to `/tmp/requirements.txt` in the image
- Running `pip install -r /tmp/requirements.txt` to install dependencies

#### Motivation and Context
When following the commands below as indicated in https://github.com/XuehaiPan/nvitop#for-docker-users, `nvitop` in the container throws an error:
- Commands
  ```
  git clone --depth=1 https://github.com/XuehaiPan/nvitop.git && cd nvitop  # clone this repo first
  docker build --tag nvitop:latest .  # build the Docker image
  docker run -it --rm --runtime=nvidia --gpus=all --pid=host nvitop:latest  # run the Docker container
  ```
- Error
  ```
  Traceback (most recent call last):
    File "/usr/lib/python3.6/runpy.py", line 183, in _run_module_as_main
      mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
    File "/usr/lib/python3.6/runpy.py", line 142, in _get_module_details
      return _get_module_details(pkg_main_name, error)
    File "/usr/lib/python3.6/runpy.py", line 109, in _get_module_details
      __import__(pkg_name)
    File "/nvitop/nvitop/__init__.py", line 19, in <module>
      from nvitop import core
    File "/nvitop/nvitop/core/__init__.py", line 19, in <module>
      from nvitop.core import host, libcuda, libnvml, utils
    File "/nvitop/nvitop/core/host.py", line 25, in <module>
      import psutil as _psutil
  ModuleNotFoundError: No module named 'psutil'
  ```
I modified `Dockerfile` so that the dependencies are explicitly installed.
By the change, the error due to lack of dependencies was resolved and `nvitop` command was successfully run.

#### Testing

I tested building the image and running `nvitop` command in a docker container in two environments mentioned above, and confirmed successful build and execution.

The change does not affect any other areas of the codebase. 

#### Images / Videos  <!-- Only if relevant -->

N/A