### PR TITLE
fix(Dockerfile): migrate docker image repo to nvcr.io/nvidia/driver

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ on:
       - pyproject.toml
       - MANIFEST.in
       - nvitop/version.py
+      - Dockerfile
       - .github/workflows/build.yaml
   release:
     types:
@@ -77,6 +78,11 @@ jobs:
             python -m pre_commit install --install-hooks &&
             python -m pre_commit run --all-files
           )
+
+      - name: Test docker build
+        run: |
+          docker build --tag nvitop:latest .
+          docker run --rm nvitop:latest --help
 
       - name: Set __release__
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-ARG basetag="470-signed-ubuntu22.04"  # Ubuntu only
+ARG basetag="450-signed-ubuntu22.04"  # Ubuntu only
 FROM nvcr.io/nvidia/driver:"${basetag}"
 
+ENV NVIDIA_DISABLE_REQUIRE=true
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update APT sources

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ docker build --tag nvitop:latest .  # build the Docker image
 docker run -it --rm --runtime=nvidia --gpus=all --pid=host nvitop:latest  # run the Docker container
 ```
 
-The [`Dockerfile`](Dockerfile) has a optional build argument `basetag` (default: `418.87.01-ubuntu18.04`) for the tag of image [`nvidia/driver`](https://hub.docker.com/r/nvidia/driver/tags).
+The [`Dockerfile`](Dockerfile) has a optional build argument `basetag` (default: `470-signed-ubuntu22.04`) for the tag of image [`nvcr.io/nvidia/driver`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver/tags).
 
 **NOTE:** Don't forget to add the `--pid=host` option when running the container.
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ docker build --tag nvitop:latest .  # build the Docker image
 docker run -it --rm --runtime=nvidia --gpus=all --pid=host nvitop:latest  # run the Docker container
 ```
 
-The [`Dockerfile`](Dockerfile) has a optional build argument `basetag` (default: `470-signed-ubuntu22.04`) for the tag of image [`nvcr.io/nvidia/driver`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver/tags).
+The [`Dockerfile`](Dockerfile) has a optional build argument `basetag` (default: `450-signed-ubuntu22.04`) for the tag of image [`nvcr.io/nvidia/driver`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver/tags).
 
 **NOTE:** Don't forget to add the `--pid=host` option when running the container.
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix
- Improvement/feature implementation

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal 3.36.2
- Python version: `3.10.8`
- NVML version (driver version): `525.60.11`
- `nvitop` version or commit: `main@c04fbb`
- `python-ml-py` version: `11.515.75`
- Locale: `en_US.UTF-8`

#### Description

<!-- Describe the changes in detail -->

- Migrate the docker image repo to [nvcr.io/nvidia/driver](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/driver). The old repo on [Docker Hub](https://hub.docker.com/r/nvidia/driver) is out of maintenance.
- Add minimal test for the `Dockerfile` in GitHub Actions.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Python 3.6 is end-of-life and the highest supported `setuptools` does not support `pyprocject.toml` based projects. It cannot install the dependencies correctly. This PR replaces the `requirements.txt` approach in #50 and updates the docker image.

Closes #50

#### Testing

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

N/A

#### Images / Videos  <!-- Only if relevant -->

<!-- Link or embed images and videos of screenshots, sketches etc. -->

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/16078332/207275341-92e5198e-b51a-44c6-a7f0-1de80013bf5c.png">
