### PR TITLE
deps(python): drop Python 3.6 support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 - Operating system and version: [e.g. Ubuntu 20.04 LTS / Windows 10 Build 19043.1110]
 - Terminal emulator and version: [e.g. GNOME Terminal 3.36.2 / Windows Terminal 1.8.1521.0]
-- Python version: [e.g. `3.6.6` / `3.9.6`]
+- Python version: [e.g. `3.7.2` / `3.9.6`]
 - NVML version (driver version): [e.g. `460.84`]
 - `nvitop` version or commit: [e.g. `0.10.0` / `0.10.1.dev7+ga083321` / `main@75ae3c`]
 - `python-ml-py` version: [e.g. `11.450.51`]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,19 +50,19 @@ jobs:
         id: py
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6 - 3.11"
+          python-version: "3.7 - 3.11"
           update-environment: true
 
-      - name: Set up Python 3.6
-        id: py36
+      - name: Set up Python 3.7
+        id: py37
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.7"
           update-environment: false
 
-      - name: Check syntax (Python 3.6)
+      - name: Check syntax (Python 3.7)
         run: |
-          "${{ steps.py36.outputs.python-path }}" -m compileall nvitop
+          "${{ steps.py37.outputs.python-path }}" -m compileall nvitop
 
       - name: Upgrade build dependencies
         run: python -m pip install --upgrade pip setuptools wheel build
@@ -123,7 +123,7 @@ jobs:
         uses: actions/setup-python@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          python-version: "3.6 - 3.11"
+          python-version: "3.7 - 3.11"
           update-environment: true
 
       - name: Set __release__

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,19 +27,19 @@ jobs:
         id: py
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6 - 3.11"
+          python-version: "3.7 - 3.11"
           update-environment: true
 
-      - name: Set up Python 3.6
-        id: py36
+      - name: Set up Python 3.7
+        id: py37
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.7"
           update-environment: false
 
-      - name: Check syntax (Python 3.6)
+      - name: Check syntax (Python 3.7)
         run: |
-          "${{ steps.py36.outputs.python-path }}" -m compileall nvitop
+          "${{ steps.py37.outputs.python-path }}" -m compileall nvitop
 
       - name: Upgrade pip
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
         stages: [commit, push, manual]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0

--- a/.pylintrc
+++ b/.pylintrc
@@ -84,7 +84,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.6
+py-version=3.7
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable html -->
 
-![Python 3.6+](https://img.shields.io/badge/Python-3.6%2B-brightgreen)
+![Python 3.7+](https://img.shields.io/badge/Python-3.7%2B-brightgreen)
 [![PyPI](https://img.shields.io/pypi/v/nvitop?label=pypi&logo=pypi)](https://pypi.org/project/nvitop)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/nvitop?label=conda&logo=condaforge)](https://anaconda.org/conda-forge/nvitop)
 [![Documentation Status](https://img.shields.io/readthedocs/nvitop?label=docs&logo=readthedocs)](https://nvitop.readthedocs.io)
@@ -103,7 +103,7 @@ An interactive NVIDIA-GPU process viewer and beyond, the one-stop solution for G
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.7+
 - NVIDIA Management Library (NVML)
 - nvidia-ml-py
 - psutil

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ An interactive NVIDIA-GPU process viewer and beyond, the one-stop solution for G
 .. |GitHub| image:: https://img.shields.io/badge/GitHub-Homepage-blue?logo=github
 .. _GitHub: https://github.com/XuehaiPan/nvitop
 
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.6%2B-brightgreen
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.7%2B-brightgreen
 .. _Python Version: https://pypi.org/project/nvitop
 
 .. |PyPI Package| image:: https://img.shields.io/pypi/v/nvitop?label=pypi&logo=pypi
@@ -56,7 +56,7 @@ Install from PyPI (|PyPI Package|_):
 
 .. note::
 
-    Python 3.6+ is required, and Python versions lower than 3.6 is not supported.
+    Python 3.7+ is required, and Python versions lower than 3.7 is not supported.
 
 Install from conda-forge (|Conda-forge Package|_):
 

--- a/nvitop/api/libcuda.py
+++ b/nvitop/api/libcuda.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=invalid-name
 
+from __future__ import annotations
+
 import ctypes as _ctypes
 import itertools as _itertools
 import platform as _platform
@@ -25,8 +27,6 @@ import string as _string
 import sys as _sys
 import threading as _threading
 from typing import Any as _Any
-from typing import Tuple as _Tuple
-from typing import Type as _Type
 
 
 # pylint: disable-next=missing-class-docstring,too-few-public-methods
@@ -229,7 +229,7 @@ class CUDAError(Exception):
     }  # fmt:skip
     _errcode_to_name = {}
 
-    def __new__(cls, value: int) -> 'CUDAError':
+    def __new__(cls, value: int) -> CUDAError:
         """Map value to a proper subclass of :class:`CUDAError`."""
         if cls is CUDAError:
             # pylint: disable-next=self-cls-assignment
@@ -264,12 +264,12 @@ class CUDAError(Exception):
             return NotImplemented
         return self.value == other.value  # pylint: disable=no-member
 
-    def __reduce__(self) -> _Tuple[_Type['CUDAError'], _Tuple[int]]:
+    def __reduce__(self) -> tuple[type[CUDAError], tuple[int]]:
         """Return state information for pickling."""
         return CUDAError, (self.value,)  # pylint: disable=no-member
 
 
-def cudaExceptionClass(cudaErrorCode: int) -> _Type[CUDAError]:
+def cudaExceptionClass(cudaErrorCode: int) -> type[CUDAError]:
     """Map value to a proper subclass of :class:`CUDAError`.
 
     Raises:

--- a/nvitop/api/libcudart.py
+++ b/nvitop/api/libcudart.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=invalid-name
 
+from __future__ import annotations
+
 import ctypes as _ctypes
 import glob as _glob
 import os as _os
@@ -25,8 +27,6 @@ import platform as _platform
 import sys as _sys
 import threading as _threading
 from typing import Any as _Any
-from typing import Tuple as _Tuple
-from typing import Type as _Type
 
 
 _cudaError_t = _ctypes.c_int
@@ -280,7 +280,7 @@ class cudaError(Exception):
     }  # fmt:skip
     _errcode_to_name = {}
 
-    def __new__(cls, value: int) -> 'cudaError':
+    def __new__(cls, value: int) -> cudaError:
         """Map value to a proper subclass of :class:`cudaError`."""
         if cls is cudaError:
             # pylint: disable-next=self-cls-assignment
@@ -315,12 +315,12 @@ class cudaError(Exception):
             return NotImplemented
         return self.value == other.value  # pylint: disable=no-member
 
-    def __reduce__(self) -> _Tuple[_Type['cudaError'], _Tuple[int]]:
+    def __reduce__(self) -> tuple[type[cudaError], tuple[int]]:
         """Return state information for pickling."""
         return cudaError, (self.value,)  # pylint: disable=no-member
 
 
-def cudaExceptionClass(cudaErrorCode: int) -> _Type[cudaError]:
+def cudaExceptionClass(cudaErrorCode: int) -> type[cudaError]:
     """Map value to a proper subclass of :class:`cudaError`.
 
     Raises:

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=invalid-name
 
+from __future__ import annotations
+
 import ctypes as _ctypes
 import functools as _functools
 import inspect as _inspect
@@ -26,15 +28,10 @@ import os as _os
 import re as _re
 import sys as _sys
 import threading as _threading
-from collections import OrderedDict as _OrderedDict
 from types import FunctionType as _FunctionType
 from types import ModuleType as _ModuleType
 from typing import Any as _Any
 from typing import Callable as _Callable
-from typing import Optional as _Optional
-from typing import Tuple as _Tuple
-from typing import Type as _Type
-from typing import Union as _Union
 
 # Python Bindings for the NVIDIA Management Library (NVML)
 # https://pypi.org/project/nvidia-ml-py
@@ -334,7 +331,7 @@ def nvmlShutdown() -> None:  # pylint: disable=function-redefined
 
 
 def nvmlQuery(
-    func: _Union[_Callable[..., _Any], str],
+    func: _Callable[..., _Any] | str,
     *args,
     default: _Any = NA,
     ignore_errors: bool = True,
@@ -419,9 +416,7 @@ def nvmlQuery(
     return retval
 
 
-def nvmlCheckReturn(
-    retval: _Any, types: _Optional[_Union[_Type, _Tuple[_Type, ...]]] = None
-) -> bool:
+def nvmlCheckReturn(retval: _Any, types: type | tuple[type, ...] | None = None) -> bool:
     """Check whether the return value is not :const:`nvitop.NA` and is one of the given types."""
     if types is None:
         return retval != NA
@@ -690,14 +685,14 @@ class _CustomModule(_ModuleType):
         ... # The NVML context has been shutdown
     """
 
-    def __getattribute__(self, name: str) -> _Union[_Any, _Callable[..., _Any]]:
+    def __getattribute__(self, name: str) -> _Any | _Callable[..., _Any]:
         """Get a member from the current module. Fallback to the original package if missing."""
         try:
             return super().__getattribute__(name)
         except AttributeError:
             return getattr(_pynvml, name)
 
-    def __enter__(self) -> '_CustomModule':  # noqa: F405
+    def __enter__(self) -> _CustomModule:  # noqa: F405
         """Entry of the context manager for ``with`` statement."""
         _lazy_init()
         return self
@@ -718,8 +713,3 @@ class _CustomModule(_ModuleType):
 __modself = _sys.modules[__name__]
 __modself.__class__ = _CustomModule
 del _CustomModule
-
-# Delete imported references
-del _logging, _os, _re, _sys, _threading
-del _OrderedDict, _FunctionType, _ModuleType
-del _Tuple, _Callable, _Type, _Union, _Optional, _Any

--- a/nvitop/api/utils.py
+++ b/nvitop/api/utils.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=invalid-name
 
+from __future__ import annotations
+
 import datetime
 import functools
 import math
@@ -25,7 +27,7 @@ import os
 import re
 import sys
 import time
-from typing import Any, Callable, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Iterable
 
 from psutil import WINDOWS
 
@@ -66,8 +68,8 @@ except ImportError:
 
     def _colored(  # pylint: disable=unused-argument
         text: str,
-        color: Optional[str] = None,
-        on_color: Optional[str] = None,
+        color: str | None = None,
+        on_color: str | None = None,
         attrs: Iterable[str] = None,
     ) -> str:
         return text
@@ -90,8 +92,8 @@ def set_color(value: bool) -> None:
 
 def colored(
     text: str,
-    color: Optional[str] = None,
-    on_color: Optional[str] = None,
+    color: str | None = None,
+    on_color: str | None = None,
     attrs: Iterable[str] = None,
 ) -> str:
     """Colorize text with ANSI color escape codes.
@@ -144,7 +146,7 @@ class NaType(str):
         nan
     """
 
-    def __new__(cls) -> 'NaType':
+    def __new__(cls) -> NaType:
         """Get the singleton instance (:const:`nvitop.NA`)."""
         if not hasattr(cls, '_instance'):
             cls._instance = super().__new__(cls, 'N/A')
@@ -176,7 +178,7 @@ class NaType(str):
         """
         return math.nan
 
-    def __add__(self, other: object) -> Union[str, float]:
+    def __add__(self, other: object) -> str | float:
         """Return :data:`math.nan` if the operand is a number or uses string concatenation if the operand is a string (``NA + other``).
 
         A special case is when the operand is :const:`nvitop.NA` itself, the result is
@@ -195,7 +197,7 @@ class NaType(str):
             return float(self) + other
         return super().__add__(other)
 
-    def __radd__(self, other: object) -> Union[str, float]:
+    def __radd__(self, other: object) -> str | float:
         """Return :data:`math.nan` if the operand is a number or uses string concatenation if the operand is a string (``other + NA``).
 
         >>> 'str' + NA
@@ -351,7 +353,7 @@ class NaType(str):
             return other % float(self)
         return NotImplemented
 
-    def __divmod__(self, other: object) -> Tuple[float, float]:
+    def __divmod__(self, other: object) -> tuple[float, float]:
         """The pair ``(NA // other, NA % other)`` (``divmod(NA, other)``).
 
         >>> divmod(NA, 1024)
@@ -365,7 +367,7 @@ class NaType(str):
         """
         return (self // other, self % other)
 
-    def __rdivmod__(self, other: object) -> Tuple[float, float]:
+    def __rdivmod__(self, other: object) -> tuple[float, float]:
         """The pair ``(other // NA, other % NA)`` (``divmod(other, NA)``).
 
         >>> divmod(1024, NA)
@@ -399,7 +401,7 @@ class NaType(str):
         """
         return abs(float(self))
 
-    def __round__(self, ndigits: Optional[int] = None) -> Union[int, float]:
+    def __round__(self, ndigits: int | None = None) -> int | float:
         """Round :const:`nvitop.NA` to ``ndigits`` decimal places, defaulting to :const:`0`.
 
         If ``ndigits`` is omitted or :data:`None`, returns :const:`0`, otherwise returns :data:`math.nan`.
@@ -494,7 +496,7 @@ SIZE_PATTERN = re.compile(
 """The regex pattern for human readable size."""
 
 
-def bytes2human(b: Union[int, float, NaType]) -> str:  # pylint: disable=too-many-return-statements
+def bytes2human(b: int | float | NaType) -> str:  # pylint: disable=too-many-return-statements
     """Convert bytes to a human readable string."""
     if b == NA:
         return NA
@@ -524,7 +526,7 @@ def bytes2human(b: Union[int, float, NaType]) -> str:  # pylint: disable=too-man
     return f'{round(b / PiB, 1):.1f}PiB'
 
 
-def human2bytes(s: Union[int, str]) -> int:
+def human2bytes(s: int | str) -> int:
     """Convert a human readable size string (*case insensitive*) to bytes.
 
     Raises:
@@ -558,7 +560,7 @@ def human2bytes(s: Union[int, str]) -> int:
     return int(float(size) * SIZE_UNITS[unit])
 
 
-def timedelta2human(dt: Union[int, float, datetime.timedelta, NaType]) -> str:
+def timedelta2human(dt: int | float | datetime.timedelta | NaType) -> str:
     """Convert a number in seconds or a :class:`datetime.timedelta` instance to a human readable string."""
     if isinstance(dt, (int, float)):
         dt = datetime.timedelta(seconds=dt)
@@ -575,7 +577,7 @@ def timedelta2human(dt: Union[int, float, datetime.timedelta, NaType]) -> str:
     return '{:d}:{:02d}'.format(*divmod(seconds, 60))
 
 
-def utilization2string(utilization: Union[int, float, NaType]) -> str:
+def utilization2string(utilization: int | float | NaType) -> str:
     """Convert a utilization rate to string."""
     if utilization != NA:
         if isinstance(utilization, int):

--- a/nvitop/callbacks/keras.py
+++ b/nvitop/callbacks/keras.py
@@ -18,9 +18,10 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 # pylint: disable=unused-argument,attribute-defined-outside-init
 
+from __future__ import annotations
+
 import re
 import time
-from typing import Dict, List, Tuple, Union
 
 from tensorflow.python.keras.callbacks import (  # pylint: disable=import-error,no-name-in-module
     Callback,
@@ -94,7 +95,7 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        gpus: Union[int, Union[List[Union[int, str]], Tuple[Union[int, str], ...]]],
+        gpus: int | list[int | str] | tuple[int | str, ...],
         memory_utilization: bool = True,
         gpu_utilization: bool = True,
         intra_step_time: bool = False,
@@ -166,7 +167,7 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
                 time.monotonic() - self._snap_intra_step_time
             )
 
-    def _get_gpu_stats(self) -> Dict[str, float]:
+    def _get_gpu_stats(self) -> dict[str, float]:
         """Get the gpu status from NVML queries."""
         return get_gpu_stats(
             devices=self._devices,

--- a/nvitop/callbacks/pytorch_lightning.py
+++ b/nvitop/callbacks/pytorch_lightning.py
@@ -18,8 +18,9 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 # pylint: disable=unused-argument,attribute-defined-outside-init
 
+from __future__ import annotations
+
 import time
-from typing import Dict
 
 from pytorch_lightning.callbacks import Callback  # pylint: disable=import-error
 from pytorch_lightning.utilities import rank_zero_only  # pylint: disable=import-error
@@ -161,7 +162,7 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
 
         trainer.logger.log_metrics(logs, step=trainer.global_step)
 
-    def _get_gpu_stats(self) -> Dict[str, float]:
+    def _get_gpu_stats(self) -> dict[str, float]:
         """Get the gpu status from NVML queries."""
         return get_gpu_stats(
             devices=self._devices,

--- a/nvitop/callbacks/tensorboard.py
+++ b/nvitop/callbacks/tensorboard.py
@@ -17,7 +17,9 @@
 
 # pylint: disable=missing-module-docstring
 
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -33,11 +35,11 @@ if TYPE_CHECKING:
 
 
 def add_scalar_dict(
-    writer: 'SummaryWriter',
+    writer: SummaryWriter,
     main_tag: str,
-    tag_scalar_dict: Dict[str, Union[int, float, 'np.floating']],
-    global_step: Optional[Union[int, 'np.integer']] = None,
-    walltime: Optional[float] = None,
+    tag_scalar_dict: dict[str, int | float | np.floating],
+    global_step: int | np.integer | None = None,
+    walltime: float | None = None,
 ) -> None:
     """Add a batch of scalars to the writer.
 

--- a/nvitop/callbacks/utils.py
+++ b/nvitop/callbacks/utils.py
@@ -17,12 +17,12 @@
 
 # pylint: disable=missing-module-docstring,missing-function-docstring
 
-from typing import Dict, List
+from __future__ import annotations
 
 from nvitop.api import CudaDevice, Device, MiB
 
 
-def get_devices_by_logical_ids(device_ids: List[int], unique: bool = True) -> List[CudaDevice]:
+def get_devices_by_logical_ids(device_ids: list[int], unique: bool = True) -> list[CudaDevice]:
     cuda_devices = CudaDevice.from_indices(device_ids)
 
     devices = []
@@ -37,12 +37,12 @@ def get_devices_by_logical_ids(device_ids: List[int], unique: bool = True) -> Li
 
 
 def get_gpu_stats(
-    devices: List[Device],
+    devices: list[Device],
     memory_utilization: bool = True,
     gpu_utilization: bool = True,
     fan_speed: bool = False,
     temperature: bool = False,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Get the GPU status from NVML queries."""
     stats = {}
     for device in devices:

--- a/nvitop/select.py
+++ b/nvitop/select.py
@@ -54,13 +54,15 @@ Python API:
     )
 """  # pylint: disable=line-too-long
 
+from __future__ import annotations
+
 import argparse
 import getpass
 import math
 import os
 import sys
 import warnings
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable
 
 from nvitop.api import Device, GpuProcess, colored, human2bytes, libnvml
 from nvitop.version import __version__
@@ -82,16 +84,16 @@ def select_devices(  # pylint: disable=too-many-branches,too-many-statements,too
     format: str = 'index',  # pylint: disable=redefined-builtin
     force_index: bool = False,
     min_count: int = 0,
-    max_count: Optional[int] = None,
-    min_free_memory: Optional[Union[int, str]] = None,  # in bytes or human readable
-    min_total_memory: Optional[Union[int, str]] = None,  # in bytes or human readable
-    max_gpu_utilization: Optional[int] = None,  # in percentage
-    max_memory_utilization: Optional[int] = None,  # in percentage
+    max_count: int | None = None,
+    min_free_memory: int | str | None = None,  # in bytes or human readable
+    min_total_memory: int | str | None = None,  # in bytes or human readable
+    max_gpu_utilization: int | None = None,  # in percentage
+    max_memory_utilization: int | None = None,  # in percentage
     tolerance: int = 0,  # in percentage
-    free_accounts: List[str] = None,
+    free_accounts: list[str] = None,
     sort: bool = True,
     **kwargs: Any,
-) -> Union[List[int], List[Tuple[int, int]], List[str]]:
+) -> list[int] | list[tuple[int, int]] | list[str]:
     """Select a subset of devices satisfying the specified criteria.
 
     Note:

--- a/nvitop/version.py
+++ b/nvitop/version.py
@@ -32,7 +32,7 @@ if not __release__:
                 ['git', 'describe', '--abbrev=7'],
                 cwd=os.path.dirname(os.path.abspath(__file__)),
                 stderr=subprocess.DEVNULL,
-                universal_newlines=True,
+                text=True,
             )
             .strip()
             .lstrip('v')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "nvitop"
 description = "An interactive NVIDIA-GPU process viewer and beyond, the one-stop solution for GPU process management."
 readme = "README.md"
-requires-python = ">= 3.6"
+requires-python = ">= 3.7"
 authors = [{ name = "Xuehai Pan", email = "XuehaiPan@pku.edu.cn" }]
 license = { text = "Apache License, Version 2.0 (Apache-2.0) & GNU General Public License, Version 3 (GPL-3.0)" }
 keywords = [
@@ -24,7 +24,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -72,7 +71,7 @@ include = ["nvitop", "nvitop.*"]
 safe = true
 line-length = 100
 skip-string-normalization = true
-target-version = ["py36", "py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.isort]
 atomic = true


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Breaking changes

#### Description

<!-- Describe the changes in detail -->

Drop Python 3.7 support and use postponed evaluation of annotations.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Python 3.6 reached end-of-life about 1 year and 2 months ago.