### PR TITLE
refactor(api): move `TTLCache` usage to CLI-only

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -57,6 +57,16 @@ jobs:
           python -m nvitop.select --version
           python -m nvitop.select --help
 
+      - name: Import tests (Python 3.7)
+        run: |
+          "${{ steps.py37.outputs.python-path }}" -m pip install --upgrade pip setuptools
+          "${{ steps.py37.outputs.python-path }}" -m pip install -r requirements.txt
+          "${{ steps.py37.outputs.python-path }}" -c 'import nvitop'
+          "${{ steps.py37.outputs.python-path }}" -m nvitop --version
+          "${{ steps.py37.outputs.python-path }}" -m nvitop --help
+          "${{ steps.py37.outputs.python-path }}" -m nvitop.select --version
+          "${{ steps.py37.outputs.python-path }}" -m nvitop.select --help
+
       - name: Install linters
         run: |
           python -m pip install --upgrade pre-commit pylint[spelling]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Move `TTLCache` usage to CLI-only by [@XuehaiPan](https://github.com/XuehaiPan) in [#66](https://github.com/XuehaiPan/nvitop/pull/66).
 
 ### Fixed
 

--- a/nvitop/api/host.py
+++ b/nvitop/api/host.py
@@ -27,7 +27,6 @@ import time as _time
 from typing import Callable as _Callable
 
 import psutil as _psutil
-from cachetools.func import ttl_cache as _ttl_cache
 from psutil import *  # noqa: F403 # pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
 
 
@@ -48,17 +47,18 @@ PsutilError = Error  # make alias # noqa: F405
 del Error  # noqa: F821 # pylint: disable=undefined-variable
 
 
-cpu_percent = _ttl_cache(ttl=0.25)(_psutil.cpu_percent)
-virtual_memory = _ttl_cache(ttl=0.25)(_psutil.virtual_memory)
-swap_memory = _ttl_cache(ttl=0.25)(_psutil.swap_memory)
+cpu_percent = _psutil.cpu_percent
+virtual_memory = _psutil.virtual_memory
+swap_memory = _psutil.swap_memory
 
 
-try:
-    load_average: _Callable[[], tuple[float, float, float]] = _ttl_cache(ttl=2.0)(
-        _psutil.getloadavg,
-    )
-    load_average.__doc__ = """Get the system load average."""
-except AttributeError:
+if hasattr(_psutil, 'getloadavg'):
+
+    def load_average() -> tuple[float, float, float]:
+        """Get the system load average."""
+        return _psutil.getloadavg()
+
+else:
 
     def load_average() -> None:
         """Get the system load average."""

--- a/nvitop/api/process.py
+++ b/nvitop/api/process.py
@@ -652,7 +652,6 @@ class GpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
         """Update the GPU consumption status from a new NVML query."""
         self.set_gpu_memory(NA)
         self.set_gpu_utilization(NA, NA, NA, NA)
-        self.device.processes.cache_clear()
         self.device.processes()
         return self.gpu_memory()
 

--- a/nvitop/gui/library/device.py
+++ b/nvitop/gui/library/device.py
@@ -3,6 +3,8 @@
 
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
+from cachetools.func import ttl_cache
+
 from nvitop.api import NA
 from nvitop.api import MigDevice as MigDeviceBase
 from nvitop.api import PhysicalDevice as DeviceBase
@@ -78,19 +80,19 @@ class Device(DeviceBase):
             self.as_snapshot()
         return self._snapshot
 
-    def mig_devices(self):
-        mig_devices = []
-
-        if self.is_mig_mode_enabled():
-            for mig_index in range(self.max_mig_device_count()):
-                try:
-                    mig_device = MigDevice(index=(self.index, mig_index))
-                except libnvml.NVMLError:
-                    break
-                else:
-                    mig_devices.append(mig_device)
-
-        return mig_devices
+    fan_speed = ttl_cache(ttl=5.0)(DeviceBase.fan_speed)
+    temperature = ttl_cache(ttl=5.0)(DeviceBase.temperature)
+    power_usage = ttl_cache(ttl=5.0)(DeviceBase.power_usage)
+    display_active = ttl_cache(ttl=5.0)(DeviceBase.display_active)
+    display_mode = ttl_cache(ttl=5.0)(DeviceBase.display_mode)
+    current_driver_model = ttl_cache(ttl=5.0)(DeviceBase.current_driver_model)
+    persistence_mode = ttl_cache(ttl=5.0)(DeviceBase.persistence_mode)
+    performance_state = ttl_cache(ttl=5.0)(DeviceBase.performance_state)
+    total_volatile_uncorrected_ecc_errors = ttl_cache(ttl=5.0)(
+        DeviceBase.total_volatile_uncorrected_ecc_errors,
+    )
+    compute_mode = ttl_cache(ttl=5.0)(DeviceBase.compute_mode)
+    mig_mode = ttl_cache(ttl=5.0)(DeviceBase.mig_mode)
 
     def memory_percent_string(self):  # in percentage
         return utilization2string(self.memory_percent())


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Breaking changes

#### Description

<!-- Describe the changes in detail -->

Move `TTLCache` usage to CLI-only. Public APIs in `nvitop.api` will always return immediate results.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

In the previous implementation, the public APIs may return cached results. Now all caching mechanisms are moved to CLI-only. This is more consistent with other packages such as `psutil.Process`.