### PR TITLE
fix(api/device): use recent timestamp for GPU process utilization query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Use recent timestamp for GPU process utilization query for more accurate per-process GPU usage by [@XuehaiPan](https://github.com/XuehaiPan) in [#85](https://github.com/XuehaiPan/nvitop/pull/85). We extend our heartfelt gratitude to [@2581543189](https://github.com/2581543189) for their invaluable assistance. Their timely comments and comprehensive feedback have greatly contributed to the improvement of this project.
 
 ### Fixed
 

--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -1700,7 +1700,10 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             samples = libnvml.nvmlQuery(
                 'nvmlDeviceGetProcessUtilization',
                 self.handle,
-                time.time_ns() // 1000,
+                # Only utilization samples that were recorded after this timestamp will be returned.
+                # The CPU timestamp, i.e. absolute Unix epoch timestamp (in microseconds), is used.
+                # Here we use the timestamp 1/4 second ago to ensure the record buffer is not empty.
+                time.time_ns() // 1000 - 250_000,
                 default=(),
             )
             for s in sorted(samples, key=lambda s: s.timeStamp):

--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -1703,8 +1703,8 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 self._timestamp,
                 default=(),
             )
-            self._timestamp = max(min((s.timeStamp for s in samples), default=0) - 2_000_000, 0)
-            for s in samples:
+            self._timestamp = min((s.timeStamp for s in samples), default=self._timestamp)
+            for s in sorted(samples, key=lambda s: s.timeStamp):
                 try:
                     processes[s.pid].set_gpu_utilization(s.smUtil, s.memUtil, s.encUtil, s.decUtil)
                 except KeyError:

--- a/nvitop/api/process.py
+++ b/nvitop/api/process.py
@@ -694,7 +694,19 @@ class GpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
         self.set_gpu_memory(NA)
         self.set_gpu_cc_protected_memory(NA)
         self.set_gpu_utilization(NA, NA, NA, NA)
-        self.device.processes()
+        processes = self.device.processes()
+        process = processes.get(self.pid, self)
+        if process is not self:
+            # The current process is gone and the instance has been removed from the cache.
+            # Update GPU status from the new instance.
+            self.set_gpu_memory(process.gpu_memory())
+            self.set_gpu_cc_protected_memory(process.gpu_cc_protected_memory())
+            self.set_gpu_utilization(
+                process.gpu_sm_utilization(),
+                process.gpu_memory_utilization(),
+                process.gpu_encoder_utilization(),
+                process.gpu_decoder_utilization(),
+            )
         return self.gpu_memory()
 
     @property


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Description

<!-- Describe the changes in detail -->

Remove the extra 2s timestamp margin for GPU process utilization. Such a margin may cause the API returns the average utilization rather than the instant values.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Resolves #83