### PR TITLE
fix(api/libnvml): fix removal for process info v3 APIs on the upstream 535.98 driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix removal for process info v3 APIs on the upstream 535.98 driver by [@XuehaiPan](https://github.com/XuehaiPan) in [#89](https://github.com/XuehaiPan/nvitop/pull/89).
 
 ### Removed
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Description

<!-- Describe the changes in detail -->

Add an extra handler to check the removal of the process info v3 APIs.

Copied from https://github.com/XuehaiPan/nvitop/issues/88#issuecomment-1680052592:

Version change:

495.46 -> 510.39.01: https://github.com/NVIDIA/nvidia-settings/commit/b2f0e7f437c42d92ed58120ec8d880f5f4b90d60

- Add process info v3 APIs but use v2 `nvmlProcessInfo_st` struct type

- default: 

    - `nvmlDeviceGetComputeRunningProcesses` -> `nvmlDeviceGetComputeRunningProcesses_v3`
    - `nvmlProcessInfo_st` -> `nvmlProcessInfo_v2_st`


530.41.03 -> 535.43.02: https://github.com/NVIDIA/nvidia-settings/commit/39c3e28e84f3ffb034abaf1ae92dbb570c207d05

- Process info v3 APIs use v3 `nvmlProcessInfo_st` struct type without a version bump

- default: 

    - `nvmlDeviceGetComputeRunningProcesses` -> `nvmlDeviceGetComputeRunningProcesses_v3`
    - `nvmlProcessInfo_st` -> `nvmlProcessInfo_v3_st`

535.86.05 -> 535.98: https://github.com/NVIDIA/nvidia-settings/commit/0cb3beffa0cb8a1f8cb405291b11a1e2eb7a4786

- Remove process info v3 APIs and v3 `nvmlProcessInfo_st` struct type

- default: 

    - `nvmlDeviceGetComputeRunningProcesses` -> `nvmlDeviceGetComputeRunningProcesses_v2`
    - `nvmlProcessInfo_st` -> `nvmlProcessInfo_v2_st`

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Fixes #88