### PR TITLE
fix(libcuda): fix `cuDeviceGetUuid()` when the UUID contains `0x00`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: debug-statements
       - id: double-quote-string-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.287
+    rev: v0.0.292
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -34,11 +34,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 23.9.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus] # sync with requires-python
@@ -57,7 +57,7 @@ repos:
             ^docs/source/conf.py$
           )
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         additional_dependencies: [".[toml]"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix `libcuda.cuDeviceGetUuid()` when the UUID contains `0x00` by [@XuehaiPan](https://github.com/XuehaiPan) in [#100](https://github.com/XuehaiPan/nvitop/pull/100).
 
 ### Removed
 

--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -3182,7 +3182,7 @@ def _cuda_visible_devices_parser(
             raise
 
         count = libcuda.cuDeviceGetCount()
-        uuids = list(map(libcuda.cuDeviceGetUuid, map(libcuda.cuDeviceGet, range(count))))
+        uuids = [libcuda.cuDeviceGetUuid(libcuda.cuDeviceGet(i)) for i in range(count)]
         queue.put(uuids)
         return
     except Exception as ex:  # noqa: BLE001 # pylint: disable=broad-except

--- a/nvitop/api/libcuda.py
+++ b/nvitop/api/libcuda.py
@@ -710,10 +710,10 @@ def cuDeviceGetUuid_v2(device: _c_CUdevice_t) -> str:
     """
     fn = __cudaGetFunctionPointer('cuDeviceGetUuid_v2')
 
-    uuid = _ctypes.create_string_buffer(16)
+    uuid = (_ctypes.c_byte * 16)()
     ret = fn(uuid, device)
     _cudaCheckReturn(ret)
-    uuid = ''.join(map('{:02x}'.format, uuid.value))
+    uuid = ''.join(map('{:02x}'.format, uuid))
     return '-'.join((uuid[:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32]))
 
 

--- a/nvitop/api/libcuda.py
+++ b/nvitop/api/libcuda.py
@@ -687,10 +687,10 @@ def cuDeviceGetUuid(device: _c_CUdevice_t) -> str:
     except CUDAError_NotFound:  # noqa: F821 # pylint: disable=undefined-variable
         fn = __cudaGetFunctionPointer('cuDeviceGetUuid')
 
-    uuid = _ctypes.create_string_buffer(16)
+    uuid = (_ctypes.c_ubyte * 16)()
     ret = fn(uuid, device)
     _cudaCheckReturn(ret)
-    uuid = ''.join(map('{:02x}'.format, uuid.value))
+    uuid = ''.join(map('{:02x}'.format, uuid))
     return '-'.join((uuid[:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32]))
 
 

--- a/nvitop/api/libcuda.py
+++ b/nvitop/api/libcuda.py
@@ -710,7 +710,7 @@ def cuDeviceGetUuid_v2(device: _c_CUdevice_t) -> str:
     """
     fn = __cudaGetFunctionPointer('cuDeviceGetUuid_v2')
 
-    uuid = (_ctypes.c_byte * 16)()
+    uuid = (_ctypes.c_ubyte * 16)()
     ret = fn(uuid, device)
     _cudaCheckReturn(ret)
     uuid = ''.join(map('{:02x}'.format, uuid))

--- a/nvitop/api/utils.py
+++ b/nvitop/api/utils.py
@@ -70,7 +70,7 @@ try:
     from termcolor import colored as _colored
 except ImportError:
 
-    def _colored(  # pylint: disable=unused-argument
+    def _colored(  # pylint: disable=unused-argument,too-many-arguments
         text: str,
         color: str | None = None,
         on_color: str | None = None,

--- a/nvitop/select.py
+++ b/nvitop/select.py
@@ -83,7 +83,7 @@ TTY = sys.stdout.isatty()
 
 
 @overload
-def select_devices(
+def select_devices(  # pylint: disable=too-many-arguments
     devices: Iterable[Device] | None,
     *,
     format: Literal['index'],  # pylint: disable=redefined-builtin
@@ -103,7 +103,7 @@ def select_devices(
 
 
 @overload
-def select_devices(
+def select_devices(  # pylint: disable=too-many-arguments
     devices: Iterable[Device] | None,
     *,
     format: Literal['uuid'],  # pylint: disable=redefined-builtin
@@ -123,7 +123,7 @@ def select_devices(
 
 
 @overload
-def select_devices(
+def select_devices(  # pylint: disable=too-many-arguments
     devices: Iterable[Device] | None,
     *,
     format: Literal['device'],  # pylint: disable=redefined-builtin
@@ -142,7 +142,7 @@ def select_devices(
     ...
 
 
-def select_devices(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals,unused-argument
+def select_devices(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals,unused-argument,too-many-arguments
     devices: Iterable[Device] | None = None,
     *,
     format: Literal['index', 'uuid', 'device'] = 'index',  # pylint: disable=redefined-builtin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ ignore = [
     # internal use and may never raise at runtime
     "S101",
     # SIM105: use `contextlib.suppress(...)` instead of try-except-pass
-    # reduce unnessary function call
+    # reduce unnecessary function call
     "SIM105",
 ]
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Description

<!-- Describe the changes in detail -->

Change string buffer to a byte array for argument passing.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Fixes #99