### PR TITLE
fix(collector): fix documentation for `ResourceMetricCollector.clear()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix documentation for the `ResourceMetricCollector.clear()` method by [@MyGodItsFull0fStars](https://github.com/MyGodItsFull0fStars) in [#132](https://github.com/XuehaiPan/nvitop/pull/132).
 - Gracefully ignore UTF-8 decoding errors by [@XuehaiPan](https://github.com/XuehaiPan).
 
 ### Removed

--- a/nvitop/api/collector.py
+++ b/nvitop/api/collector.py
@@ -585,6 +585,8 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
                     break
                 buffer = buffer.prev  # type: ignore[assignment]
 
+    reset = clear
+    
     def collect(self) -> dict[str, float]:
         """Get the average resource consumption during collection."""
         with self._lock:

--- a/nvitop/api/collector.py
+++ b/nvitop/api/collector.py
@@ -586,7 +586,7 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
                 buffer = buffer.prev  # type: ignore[assignment]
 
     reset = clear
-    
+
     def collect(self) -> dict[str, float]:
         """Get the average resource consumption during collection."""
         with self._lock:

--- a/nvitop/api/collector.py
+++ b/nvitop/api/collector.py
@@ -296,7 +296,7 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
 
         collector.activate(tag='<tag>')  # alias: start
         collector.deactivate()           # alias: stop
-        collector.reset(tag='<tag>')
+        collector.clear(tag='<tag>')
         collector.collect()
 
         with collector(tag='<tag>'):
@@ -539,14 +539,14 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
     __call__ = context  # alias for `with collector(tag='<tag>')`
 
     def clear(self, tag: str | None = None) -> None:
-        """Reset the metric collection with the given tag.
+        """Clear the metric collection with the given tag.
 
-        If the tag is not specified, reset the current active collection. For nested collections,
-        the sub-collections will be reset as well.
+        If the tag is not specified, clear the current active collection. For nested collections,
+        the sub-collections will be cleared as well.
 
         Args:
             tag (Optional[str]):
-                The tag to reset. If :data:`None`, the current active collection will be reset.
+                The tag to clear. If :data:`None`, the current active collection will be reset.
 
         Examples:
             >>> collector = ResourceMetricCollector()
@@ -558,12 +558,12 @@ class ResourceMetricCollector:  # pylint: disable=too-many-instance-attributes
             ...     time.sleep(5.0)
             ...     collector.collect()               # metrics within the cumulative 10.0s interval
             ...
-            ...     collector.reset()                 # reset the active collection
+            ...     collector.clear()                 # clear the active collection
             ...     time.sleep(5.0)
             ...     collector.collect()               # metrics within the 5.0s interval
             ...
             ...     with collector(tag='batch'):      # key prefix -> 'train/batch'
-            ...         collector.reset(tag='train')  # reset both 'train' and 'train/batch'
+            ...         collector.clear(tag='train')  # clear both 'train' and 'train/batch'
         """
         with self._lock:
             if self._metric_buffer is None:


### PR DESCRIPTION
The docstrings of `ResourceMetricCollector` referred to the `clear()` function as `reset()`, which is not existing. 
Therefore, I replaced each mention of `reset()` with `clear()` in the documentation.

#### Issue Type

- Improvement/feature implementation

#### Runtime Environment

- Operating system and version: [e.g. Ubuntu 20.04 LTS / Windows 10 Build 19043.1110]
- Terminal emulator and version: [e.g. GNOME Terminal 3.36.2 / Windows Terminal 1.8.1521.0]
- Python version: [e.g. `3.7.2` / `3.9.6`]
- NVML version (driver version): [e.g. `460.84`]
- `nvitop` version or commit: [e.g. `0.10.0` / `0.10.1.dev7+ga083321` / `main@75ae3c`]
- `python-ml-py` version: [e.g. `11.450.51`]
- Locale: [e.g. `C` / `C.UTF-8` / `en_US.UTF-8`]

#### Description

Within the `ResourceMetricCollector` class, the `clear()` function was not used in the documentation for the class, nor the docstring of the function itself, but `reset()`.

As the `reset()` function is not existing for `ResourceMetricCollector`, I replaced all occurrences of it in the documentation with `clear()` as well as changing the description of the `clear()` function to reflect it's name better.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

The motivation is, that I was looking at the documentation and tried to use the `reset()` function for a `ResourceMetricCollector` instance, and encountered an error.
I had to look at the code to see that the function I have to use is called `clear()`.

#### Testing

As I only changed the docstrings within the `ResourceMetricCollector` class, I did not test my changes.

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

