### PR TITLE
chore(callbacks): deprecate `nvitop.callbacks` as officially unmaintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Deprecate `nvitop.callbacks` as officially unmaintained by [@XuehaiPan](https://github.com/XuehaiPan) in [#157](https://github.com/XuehaiPan/nvitop/pull/157).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An interactive NVIDIA-GPU process viewer and beyond, the one-stop solution for G
     - [Command Line Options and Environment Variables](#command-line-options-and-environment-variables)
     - [Keybindings for Monitor Mode](#keybindings-for-monitor-mode)
   - [CUDA Visible Devices Selection Tool](#cuda-visible-devices-selection-tool)
-  - [Callback Functions for Machine Learning Frameworks](#callback-functions-for-machine-learning-frameworks)
+  - [Callback Functions for Machine Learning Frameworks (DEPRECATED)](#callback-functions-for-machine-learning-frameworks-deprecated)
     - [Callback for TensorFlow (Keras)](#callback-for-tensorflow-keras)
     - [Callback for PyTorch Lightning](#callback-for-pytorch-lightning)
     - [TensorBoard Integration](#tensorboard-integration)
@@ -600,7 +600,7 @@ formatting:
 
 ------
 
-### Callback Functions for Machine Learning Frameworks
+### Callback Functions for Machine Learning Frameworks (DEPRECATED)
 
 `nvitop` provides two builtin callbacks for [TensorFlow (Keras)](https://www.tensorflow.org) and [PyTorch Lightning](https://pytorchlightning.ai).
 

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -1,5 +1,5 @@
-nvitop.callbacks package
-========================
+nvitop.callbacks package (DEPRECATED)
+=====================================
 
 Submodules
 ----------

--- a/nvitop/callbacks/__init__.py
+++ b/nvitop/callbacks/__init__.py
@@ -14,3 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+# pylint: disable=missing-module-docstring
+
+import warnings
+
+
+warnings.warn(
+    f'The `{__name__}` module is deprecated '
+    'and will not be supported in the future. '
+    'Feel free to port and implement your own callback using `nvitop`.',
+    category=FutureWarning,
+    stacklevel=2,
+)

--- a/nvitop/callbacks/keras.py
+++ b/nvitop/callbacks/keras.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 import time
+import warnings
 
 # pylint: disable-next=import-error,no-name-in-module
 from tensorflow.python.keras.callbacks import Callback
@@ -102,6 +103,14 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         fan_speed: bool = False,
         temperature: bool = False,
     ) -> None:
+        warnings.warn(
+            f'`{__name__}.{self.__class__.__name__}` is deprecated '
+            'and will not be supported in the future. '
+            'Feel free to port and implement your own callback using `nvitop`.',
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         super().__init__()
 
         try:

--- a/nvitop/callbacks/lightning.py
+++ b/nvitop/callbacks/lightning.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from lightning.pytorch.callbacks import Callback  # pylint: disable=import-error
@@ -97,6 +98,14 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         fan_speed: bool = False,
         temperature: bool = False,
     ) -> None:
+        warnings.warn(
+            f'The class `{__name__}.{self.__class__.__name__}` is deprecated '
+            'and will not be supported in the future. '
+            'Feel free to port and implement your own callback using `nvitop`.',
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         super().__init__()
 
         try:

--- a/nvitop/callbacks/pytorch_lightning.py
+++ b/nvitop/callbacks/pytorch_lightning.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from pytorch_lightning.callbacks import Callback  # pylint: disable=import-error
@@ -97,6 +98,14 @@ class GpuStatsLogger(Callback):  # pylint: disable=too-many-instance-attributes
         fan_speed: bool = False,
         temperature: bool = False,
     ) -> None:
+        warnings.warn(
+            f'The class `{__name__}.{self.__class__.__name__}` is deprecated '
+            'and will not be supported in the future. '
+            'Feel free to port and implement your own callback using `nvitop`.',
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         super().__init__()
 
         try:

--- a/nvitop/callbacks/tensorboard.py
+++ b/nvitop/callbacks/tensorboard.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 
@@ -32,6 +33,15 @@ if TYPE_CHECKING:
             from tensorboardX import SummaryWriter
         except ImportError:
             pass
+
+
+warnings.warn(
+    f'The `{__name__}` module is deprecated '
+    'and will not be supported in the future. '
+    'Feel free to port and implement your own callback using `nvitop`.',
+    category=FutureWarning,
+    stacklevel=2,
+)
 
 
 def add_scalar_dict(


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Breaking changes

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Deprecate `nvitop.callbacks` as officially unmaintained due to upstream dependencies.