### PR TITLE
Adds workflow to publish nvitop-exporter

### DIFF
--- a/.github/workflows/publish-nvitop-exporter.yaml
+++ b/.github/workflows/publish-nvitop-exporter.yaml
@@ -1,0 +1,67 @@
+name: Build and Publish nvitop-exporter
+
+on:
+  pull_request:
+    paths:
+      - setup.py
+      - setup.cfg
+      - pyproject.toml
+      - MANIFEST.in
+      - nvitop/version.py
+  release:
+    types:
+      - published
+  workflow_dispatch:  # Allow manual trigger
+    inputs:
+      publish:
+        description: 'Publish to GHCR'
+        type: boolean
+        default: true
+        required: false
+      version:
+        description: 'Version tag to publish'
+        type: string
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nvitop
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -t test-image:latest ./nvitop-exporter
+
+      - name: Test Docker image
+        run: |
+          docker run --rm test-image:latest --help
+
+      - name: Login and push Docker image
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+          # Extract version from tag (e.g., v1.0.0 -> exporter-v1.0.0)
+          VERSION=${GITHUB_REF#refs/tags/}
+          TAG="exporter-${VERSION}"
+          IMAGE_FULL_NAME="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${TAG}"
+
+          echo "Tagging and pushing: ${IMAGE_FULL_NAME}"
+          docker tag test-image:latest "${IMAGE_FULL_NAME}"
+          docker push "${IMAGE_FULL_NAME}"


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
- Creates a new GitHub Actions workflow to automatically build and publish the nvitop-exporter Docker image to GitHub Container Registry (GHCR) on releases.

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### Runtime Environment

<!-- Details of your runtime environment -->

- Operating system and version: [e.g. Ubuntu 20.04 LTS / Windows 10 Build 19043.1110]
- Terminal emulator and version: [e.g. GNOME Terminal 3.36.2 / Windows Terminal 1.8.1521.0]
- Python version: [e.g. `3.8.2` / `3.9.6`]
- NVML version (driver version): [e.g. `460.84`]
- `nvitop` version or commit: [e.g. `0.10.0` / `0.10.1.dev7+ga083321` / `main@75ae3c`]
- `python-ml-py` version: [e.g. `11.450.51`]
- Locale: [e.g. `C` / `C.UTF-8` / `en_US.UTF-8`]

#### Description

<!-- Describe the changes in detail -->


#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### Testing

<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### Images / Videos  <!-- Only if relevant -->

<!-- Link or embed images and videos of screenshots, sketches etc. -->
