### PR TITLE
fix(api/process): fix snapshot cache for GPU processes with shared host process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Minor tweak display for device name in TUI by [@XuehaiPan](https://github.com/XuehaiPan).
 
 ### Fixed
 
--
+- Fix snapshot cache for GPU processes with shared host process by [@XuehaiPan](https://github.com/XuehaiPan) in [#172](https://github.com/XuehaiPan/nvitop/pull/172).
 
 ### Removed
 

--- a/nvitop/api/process.py
+++ b/nvitop/api/process.py
@@ -963,7 +963,8 @@ class GpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
             snapshots with :meth:`GpuProcess.take_snapshots`, which caches the results and reduces
             redundant queries. See also :meth:`take_snapshots` and :meth:`failsafe`.
         """
-        host_process_snapshot_cache = host_process_snapshot_cache or {}
+        if host_process_snapshot_cache is None:
+            host_process_snapshot_cache = {}
         try:
             host_snapshot = host_process_snapshot_cache[self.pid]
         except KeyError:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type

<!-- Pick relevant types and delete the rest -->

- Bug fix

#### Description

<!-- Describe the changes in detail -->

Do not reassign the cache to a new `dict` if it is empty.

#### Motivation and Context

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Fixes #171