### PR TITLE
fix typo that retrieves RX instead of TX in pcie_tx_throughput()

### DIFF
--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -1490,7 +1490,7 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             return libnvml.nvmlQuery(
                 'nvmlDeviceGetPcieThroughput',
                 self._handle,
-                libnvml.NVML_PCIE_UTIL_RX_BYTES,
+                libnvml.NVML_PCIE_UTIL_TX_BYTES,
             )
         return NA
 


### PR DESCRIPTION
#### Issue Type

- Bug fix

#### Runtime Environment

..

#### Description

Trivial typo fix. The pcie_tx_throughput() function was reading the RX value instead of the TX value.

#### Motivation and Context

Problem: Unable to collect PCIe Tx metrics.

#### Testing

I manually tested it. Given that it's a minor correction, I won't include it in the log, but I can add it if required.

