### PR TITLE
Fix incorrect memory reporting on coherent UMA platforms (GB10 / DGX …

### DIFF
--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -985,13 +985,21 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 memory_info = NA
             if libnvml.nvmlCheckReturn(memory_info):
                 if memory_info.total > 0:
-                    return MemoryInfo(
-                        total=memory_info.total,
-                        free=memory_info.free,
-                        used=memory_info.used,
-                        reserved=getattr(memory_info, 'reserved', NA),
-                    )
-                has_unified_memory = True
+                    # Detect coherent UMA platforms (e.g. GB10 Grace Blackwell):
+                    # nvmlDeviceGetMemoryInfo returns NVML_SUCCESS with total == system MemTotal (~121GB).
+                    # If total >= 90% of system RAM, treat as unified memory and use MemAvailable instead.
+                    vm = host.virtual_memory()
+                    if vm.total > 0 and memory_info.total >= vm.total * 9 // 10:
+                        has_unified_memory = True
+                    else:
+                        return MemoryInfo(
+                            total=memory_info.total,
+                            free=memory_info.free,
+                            used=memory_info.used,
+                            reserved=getattr(memory_info, 'reserved', NA),
+                        )
+                else:
+                    has_unified_memory = True
             if has_unified_memory:
                 # Device with unified memory
                 # Use system virtual memory as these devices share host memory

--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -985,7 +985,7 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
                 memory_info = NA
             if libnvml.nvmlCheckReturn(memory_info):
                 if memory_info.total > 0:
-                    # Detect coherent UMA platforms (e.g. GB10 Grace Blackwell):
+                    # Detect coherent unified-memory platforms (e.g. GB10 Grace Blackwell):
                     # nvmlDeviceGetMemoryInfo returns NVML_SUCCESS with total == system MemTotal (~121GB).
                     # If total >= 90% of system RAM, treat as unified memory and use MemAvailable instead.
                     vm = host.virtual_memory()


### PR DESCRIPTION
Fix incorrect memory reporting on coherent UMA platforms (GB10 / DGX Spark)

On GB10 / DGX Spark, `nvmlDeviceGetMemoryInfo` returns `NVML_SUCCESS` with `total` equal to system `MemTotal` (~121GB). This causes nvitop to display full system RAM as GPU memory instead of actually allocatable memory.

The existing `NVMLError_NotSupported` path correctly handles some UMA platforms, but GB10 returns `NVML_SUCCESS` — not `NOT_SUPPORTED` — so it falls through to the discrete GPU path and displays wrong values.

#### Issue Type

- Bug fix

#### Description

Detect coherent UMA by comparing NVML-reported `total` against system virtual memory total. If total >= 90% of system RAM, classify as unified memory and use system virtual memory (`MemAvailable`) for display instead.

Preserves existing behavior for discrete GPUs.

#### Motivation and Context

Same root cause documented and fixed in:
- nvtop PR: https://github.com/Syllo/nvtop/pull/463
- btop PR: https://github.com/aristocratos/btop/pull/1611
- NVML shim workaround: https://github.com/parallelArchitect/nvml-unified-shim

#### Note

Requires validation on GB10 / DGX Spark hardware. The fix has not been independently validated on a coherent UMA system.
