### PR TITLE
feat(api): add GDDR6/GDDR6X VRAM temperature reading via BAR0 registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `nvidia-ml-py` 13.595.45 to support list.
+- Add GDDR6/GDDR6X VRAM memory temperature reading via GPU BAR0 registers for supported NVIDIA GPUs (Linux, root, `iomem=relaxed` required).
+- Add conditional MTmp column to TUI device panel when VRAM temperature data is available.
 
 ### Changed
 

--- a/nvitop/api/device.py
+++ b/nvitop/api/device.py
@@ -1473,6 +1473,23 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
             )
         return NA
 
+    def vram_temperature(self) -> int | NaType:  # in Celsius
+        """VRAM (memory) temperature in degrees C, read via BAR0 register.
+
+        Requires root access and kernel parameter ``iomem=relaxed``.
+        Only supported on specific NVIDIA GPUs with GDDR6/GDDR6X memory.
+
+        Returns: Union[int, NaType]
+            The VRAM temperature in Celsius degrees, or :const:`nvitop.NA` when not applicable.
+        """
+        from nvitop.api.libgddr6 import read_vram_temperature
+
+        bus_id = self.bus_id()
+        if bus_id is NA:
+            return NA
+        temp = read_vram_temperature(bus_id)
+        return temp if temp is not None else NA
+
     @memoize_when_activated
     def power_usage(self) -> int | NaType:  # in milliwatts (mW)
         """The last measured power draw for the entire board in milliwatts.
@@ -2398,6 +2415,7 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
         'memory_clock',
         'fan_speed',
         'temperature',
+        'vram_temperature',
         'power_usage',
         'power_limit',
         'power_status',

--- a/nvitop/api/libgddr6.py
+++ b/nvitop/api/libgddr6.py
@@ -1,0 +1,244 @@
+# This file is part of nvitop, the interactive NVIDIA-GPU process viewer.
+#
+# Copyright 2021-2025 Xuehai Pan. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Ported from olealgoritme/gddr6 (https://github.com/olealgoritme/gddr6)
+"""Read GDDR6/GDDR6X VRAM temperatures from NVIDIA GPU BAR0 registers.
+
+This module reads memory temperatures directly from GPU BAR0 memory-mapped registers
+via ``/dev/mem``. It requires Linux, root access, and the ``iomem=relaxed`` kernel
+parameter. Only specific NVIDIA GPUs with GDDR6/GDDR6X memory are supported.
+
+When requirements are not met, :func:`read_vram_temperature` returns ``None`` gracefully.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import mmap
+import os
+import struct
+import threading
+
+
+__all__ = ['read_vram_temperature']
+
+logger = logging.getLogger(__name__)
+
+# PCI device ID -> (register_offset, vram_type, arch, name)
+GDDR6_DEVICE_TABLE: dict[int, tuple[int, str, str, str]] = {
+    0x2684: (0x0000E2A8, 'GDDR6X', 'AD102', 'RTX 4090'),
+    0x2685: (0x0000E2A8, 'GDDR6X', 'AD102', 'RTX 4090 D'),
+    0x2702: (0x0000E2A8, 'GDDR6X', 'AD103', 'RTX 4080 Super'),
+    0x2704: (0x0000E2A8, 'GDDR6X', 'AD103', 'RTX 4080'),
+    0x2705: (0x0000E2A8, 'GDDR6X', 'AD103', 'RTX 4070 Ti Super'),
+    0x2782: (0x0000E2A8, 'GDDR6X', 'AD104', 'RTX 4070 Ti'),
+    0x2783: (0x0000E2A8, 'GDDR6X', 'AD104', 'RTX 4070 Super'),
+    0x2786: (0x0000E2A8, 'GDDR6X', 'AD104', 'RTX 4070'),
+    0x2860: (0x0000E2A8, 'GDDR6', 'AD106', 'RTX 4070 Max-Q / Mobile'),
+    0x2203: (0x0000E2A8, 'GDDR6X', 'GA102', 'RTX 3090 Ti'),
+    0x2204: (0x0000E2A8, 'GDDR6X', 'GA102', 'RTX 3090'),
+    0x2208: (0x0000E2A8, 'GDDR6X', 'GA102', 'RTX 3080 Ti'),
+    0x2206: (0x0000E2A8, 'GDDR6X', 'GA102', 'RTX 3080'),
+    0x2216: (0x0000E2A8, 'GDDR6X', 'GA102', 'RTX 3080 LHR'),
+    0x2484: (0x0000EE50, 'GDDR6', 'GA104', 'RTX 3070'),
+    0x2488: (0x0000EE50, 'GDDR6', 'GA104', 'RTX 3070 LHR'),
+    0x2531: (0x0000E2A8, 'GDDR6', 'GA106', 'RTX A2000'),
+    0x2571: (0x0000E2A8, 'GDDR6', 'GA106', 'RTX A2000'),
+    0x2232: (0x0000E2A8, 'GDDR6', 'GA102', 'RTX A4500'),
+    0x2231: (0x0000E2A8, 'GDDR6', 'GA102', 'RTX A5000'),
+    0x26B1: (0x0000E2A8, 'GDDR6', 'AD102', 'RTX A6000'),
+    0x27B8: (0x0000E2A8, 'GDDR6', 'AD104', 'L4'),
+    0x26B9: (0x0000E2A8, 'GDDR6', 'AD102', 'L40S'),
+    0x2236: (0x0000E2A8, 'GDDR6', 'GA102', 'A10'),
+}
+
+
+def _nvml_bus_id_to_sysfs_path(bus_id: str) -> str:
+    """Convert NVML bus_id format to sysfs device path.
+
+    NVML returns e.g. ``'00000000:0A:00.0'``, sysfs uses ``'0000:0a:00.0'``.
+    """
+    parts = bus_id.split(':')
+    if len(parts) == 3:
+        domain = f'{int(parts[0], 16):04x}'
+        sysfs_id = f'{domain}:{parts[1].lower()}:{parts[2].lower()}'
+    else:
+        sysfs_id = bus_id.lower()
+    return f'/sys/bus/pci/devices/{sysfs_id}'
+
+
+class GDDR6Context:
+    """Singleton context for reading GDDR6/GDDR6X VRAM temperatures."""
+
+    def __init__(self) -> None:
+        """Initialize the GDDR6 context."""
+        self._fd: int | None = None
+        self._available: bool | None = None
+        self._mmap_cache: dict[int, mmap.mmap] = {}
+        self._device_info_cache: dict[str, tuple[int, int] | None] = {}
+        self._lock = threading.Lock()
+        self._warned: set[str] = set()
+
+    def _ensure_init(self) -> bool:
+        """Open ``/dev/mem`` for reading, returning whether it succeeded."""
+        if self._available is not None:
+            return self._available
+
+        with self._lock:
+            if self._available is not None:
+                return self._available
+
+            try:
+                self._fd = os.open('/dev/mem', os.O_RDONLY)
+                self._available = True
+                atexit.register(self.cleanup)
+            except PermissionError:
+                logger.debug('Cannot open /dev/mem: permission denied (need root)')
+                self._available = False
+            except FileNotFoundError:
+                logger.debug('/dev/mem not found')
+                self._available = False
+            except OSError as e:
+                logger.debug('Cannot open /dev/mem: %s', e)
+                self._available = False
+
+        return self._available
+
+    def _get_device_info(self, bus_id: str) -> tuple[int, int] | None:
+        """Get (register_offset, bar0_address) for a device, or ``None`` if unsupported."""
+        if bus_id in self._device_info_cache:
+            return self._device_info_cache[bus_id]
+
+        sysfs_path = _nvml_bus_id_to_sysfs_path(bus_id)
+        result = None
+
+        try:
+            with open(f'{sysfs_path}/device', encoding='ascii') as f:
+                dev_id = int(f.read().strip(), 16)
+
+            entry = GDDR6_DEVICE_TABLE.get(dev_id)
+            if entry is not None:
+                offset = entry[0]
+                with open(f'{sysfs_path}/resource', encoding='ascii') as f:
+                    first_line = f.readline().strip()
+                bar0 = int(first_line.split()[0], 16)
+                if bar0 != 0:
+                    result = (offset, bar0)
+        except (OSError, ValueError, IndexError):
+            pass
+
+        self._device_info_cache[bus_id] = result
+        return result
+
+    def read_vram_temperature(self, bus_id: str) -> int | None:
+        """Read VRAM temperature for a specific GPU.
+
+        Args:
+            bus_id: PCI bus ID as returned by NVML (e.g. ``'00000000:0A:00.0'``).
+
+        Returns:
+            Temperature in Celsius, or ``None`` if unavailable.
+        """
+        if not self._ensure_init():
+            return None
+
+        device_info = self._get_device_info(bus_id)
+        if device_info is None:
+            return None
+
+        offset, bar0 = device_info
+        phys_addr = bar0 + offset
+        page_size = os.sysconf('SC_PAGE_SIZE')
+        base_addr = phys_addr & ~(page_size - 1)
+        page_offset = phys_addr - base_addr
+
+        try:
+            mapped = self._get_mmap(base_addr, page_size)
+            if mapped is None:
+                return None
+
+            raw_value = struct.unpack_from('<I', mapped, page_offset)[0]
+        except Exception:  # noqa: BLE001
+            if bus_id not in self._warned:
+                self._warned.add(bus_id)
+                logger.debug('Failed to read VRAM temperature for %s', bus_id)
+            return None
+        else:
+            return (raw_value & 0x00000FFF) // 0x20
+
+    def _get_mmap(self, base_addr: int, length: int) -> mmap.mmap | None:
+        """Get or create a memory mapping for a physical address region."""
+        if base_addr in self._mmap_cache:
+            return self._mmap_cache[base_addr]
+
+        with self._lock:
+            if base_addr in self._mmap_cache:
+                return self._mmap_cache[base_addr]
+
+            try:
+                mapped = mmap.mmap(
+                    self._fd,  # type: ignore[arg-type]
+                    length,
+                    mmap.MAP_SHARED,
+                    mmap.PROT_READ,
+                    offset=base_addr,
+                )
+            except OSError:
+                key = str(base_addr)
+                if key not in self._warned:
+                    self._warned.add(key)
+                    logger.debug(
+                        'mmap failed for address 0x%x (iomem=relaxed needed?)',
+                        base_addr,
+                    )
+                return None
+            else:
+                self._mmap_cache[base_addr] = mapped
+                return mapped
+
+    def cleanup(self) -> None:
+        """Close all memory mappings and the ``/dev/mem`` file descriptor."""
+        for mapped in self._mmap_cache.values():
+            try:
+                mapped.close()
+            except Exception:  # noqa: BLE001,S110,PERF203
+                pass  # Best-effort cleanup; nothing to do on failure
+        self._mmap_cache.clear()
+
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+
+        self._available = None
+
+
+_context = GDDR6Context()
+
+
+def read_vram_temperature(bus_id: str) -> int | None:
+    """Read VRAM temperature for the GPU at the given PCI bus ID.
+
+    Args:
+        bus_id: PCI bus ID as returned by NVML (e.g. ``'00000000:0A:00.0'``).
+
+    Returns:
+        Temperature in Celsius, or ``None`` if unavailable.
+    """
+    return _context.read_vram_temperature(bus_id)

--- a/nvitop/tui/library/device.py
+++ b/nvitop/tui/library/device.py
@@ -51,6 +51,7 @@ class Device(DeviceBase):  # pylint: disable=too-many-public-methods
         'memory_utilization',
         'fan_speed',
         'temperature',
+        'vram_temperature',
         'power_usage',
         'power_limit',
         'power_status',
@@ -68,6 +69,7 @@ class Device(DeviceBase):  # pylint: disable=too-many-public-methods
         'gpu_utilization_string',
         'fan_speed_string',
         'temperature_string',
+        'vram_temperature_string',
         'memory_loading_intensity',
         'memory_display_color',
         'bandwidth_loading_intensity',
@@ -117,6 +119,7 @@ class Device(DeviceBase):  # pylint: disable=too-many-public-methods
 
     fan_speed = ttl_cache(ttl=5.0)(DeviceBase.fan_speed)
     temperature = ttl_cache(ttl=5.0)(DeviceBase.temperature)
+    vram_temperature = ttl_cache(ttl=5.0)(DeviceBase.vram_temperature)
     display_active = ttl_cache(ttl=5.0)(DeviceBase.display_active)
     display_mode = ttl_cache(ttl=5.0)(DeviceBase.display_mode)
     current_driver_model = ttl_cache(ttl=5.0)(DeviceBase.current_driver_model)
@@ -152,6 +155,10 @@ class Device(DeviceBase):  # pylint: disable=too-many-public-methods
     def temperature_string(self) -> str:  # in Celsius
         temperature = self.temperature()
         return f'{temperature}C' if libnvml.nvmlCheckReturn(temperature, int) else NA
+
+    def vram_temperature_string(self) -> str:  # in Celsius
+        vram_temp = self.vram_temperature()
+        return f'{vram_temp}C' if vram_temp is not NA and isinstance(vram_temp, int) else NA
 
     def memory_loading_intensity(self) -> LoadingIntensity:
         return self.loading_intensity_of(self.memory_percent(), type='memory')

--- a/nvitop/tui/screens/main/__init__.py
+++ b/nvitop/tui/screens/main/__init__.py
@@ -78,6 +78,7 @@ class MainScreen(BaseSelectableScreen):  # pylint: disable=too-many-instance-att
             compact,
             win=win,
             root=root,
+            base_width=self.device_panel.base_width,
         )
         self.host_panel.focused = False
         self.add_child(self.host_panel)
@@ -191,7 +192,7 @@ class MainScreen(BaseSelectableScreen):  # pylint: disable=too-many-instance-att
             print_width = min(panel.print_width() for panel in self.container)
             self.width = max(print_width, min(self.width, 140))
         else:
-            self.width = 79
+            self.width = self.device_panel.base_width
         for panel in self.container:
             panel.width = self.width
             panel.print()

--- a/nvitop/tui/screens/main/panels/device.py
+++ b/nvitop/tui/screens/main/panels/device.py
@@ -70,7 +70,6 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         self.leaf_device_count: int = len(self.leaf_devices)
 
         self._compact: bool = compact
-        self.width: int = max(79, root.width)
         self.compact_height: int = (
             4 + 2 * (self.device_count + 1) + self.mig_device_count + self.mig_enabled_device_count
         )
@@ -93,30 +92,72 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         )
         self._daemon_running = threading.Event()
 
-        self.formats_compact: list[str] = [
-            (
-                '│ {physical_index:>3} {fan_speed_string:>3} {temperature_string:>4} '
-                '{performance_state:<3}{power_status:>13} '
-                '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
-            ),
-        ]
-        self.formats_full: list[str] = [
-            (
-                '│ {physical_index:>3}  {name:<19} {persistence_mode:>4} '
-                '│ {bus_id:<16} {display_active:>3} │ {total_volatile_uncorrected_ecc_errors:>20} │'
-            ),
-            (
-                '│ {fan_speed_string:>3}  {temperature_string:>4}  {performance_state:^4} {power_status:>13} '
-                '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
-            ),
-        ]
+        self.has_vram_temp: bool = any(
+            device.vram_temperature is not NA
+            for device in self.snapshots
+            if not device.is_mig_device
+        )
+        self.base_width: int = 84 if self.has_vram_temp else 79
+        self._fsw: int = 36 if self.has_vram_temp else 31  # first section width
+        self._name_maxlen: int = 24 if self.has_vram_temp else 19
+        self._mig_name_width: int = 17 if self.has_vram_temp else 12
 
-        self.mig_formats: list[str] = [
-            (
-                '│{physical_index:>2}:{mig_index:<2}{name:>12} @ GI/CI:{gpu_instance_id:>2}/{compute_instance_id:<2}'
-                '│ {memory_usage:>20} │ BAR1: {bar1_memory_used_human:>8} / {bar1_memory_percent_string:>3} │'
-            ),
-        ]
+        self.width: int = max(self.base_width, root.width)
+
+        if self.has_vram_temp:
+            self.formats_compact: list[str] = [
+                (
+                    '│ {physical_index:>3} {fan_speed_string:>3} {temperature_string:>4} '
+                    '{vram_temperature_string:>4} {performance_state:<3}{power_status:>13} '
+                    '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
+                ),
+            ]
+            self.formats_full: list[str] = [
+                (
+                    '│ {physical_index:>3}  {name:<24} {persistence_mode:>4} '
+                    '│ {bus_id:<16} {display_active:>3} │ {total_volatile_uncorrected_ecc_errors:>20} │'
+                ),
+                (
+                    '│ {fan_speed_string:>3}  {temperature_string:>4} {vram_temperature_string:>4}  '
+                    '{performance_state:^4} {power_status:>13} '
+                    '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
+                ),
+            ]
+            self.mig_formats: list[str] = [
+                (
+                    '│{physical_index:>2}:{mig_index:<2}{name:>17}'
+                    ' @ GI/CI:{gpu_instance_id:>2}/{compute_instance_id:<2}'
+                    '│ {memory_usage:>20} │ BAR1: {bar1_memory_used_human:>8}'
+                    ' / {bar1_memory_percent_string:>3} │'
+                ),
+            ]
+        else:
+            self.formats_compact: list[str] = [  # type: ignore[no-redef]
+                (
+                    '│ {physical_index:>3} {fan_speed_string:>3} {temperature_string:>4} '
+                    '{performance_state:<3}{power_status:>13} '
+                    '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
+                ),
+            ]
+            self.formats_full: list[str] = [  # type: ignore[no-redef]
+                (
+                    '│ {physical_index:>3}  {name:<19} {persistence_mode:>4} '
+                    '│ {bus_id:<16} {display_active:>3} │ {total_volatile_uncorrected_ecc_errors:>20} │'
+                ),
+                (
+                    '│ {fan_speed_string:>3}  {temperature_string:>4}  '
+                    '{performance_state:^4} {power_status:>13} '
+                    '│ {memory_usage:>20} │ {gpu_utilization_string:>7}  {compute_mode:>11} │'
+                ),
+            ]
+            self.mig_formats: list[str] = [  # type: ignore[no-redef]
+                (
+                    '│{physical_index:>2}:{mig_index:<2}{name:>12}'
+                    ' @ GI/CI:{gpu_instance_id:>2}/{compute_instance_id:<2}'
+                    '│ {memory_usage:>20} │ BAR1: {bar1_memory_used_human:>8}'
+                    ' / {bar1_memory_percent_string:>3} │'
+                ),
+            ]
 
         if IS_WINDOWS:
             self.formats_full[0] = self.formats_full[0].replace(
@@ -142,7 +183,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
     @width.setter
     def width(self, value: int) -> None:
-        width = max(79, value)
+        width = max(self.base_width, value)
         if self._width != width and self.visible:
             self.need_redraw = True
         self._width = width
@@ -194,7 +235,12 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                         else f'{round(device.bar1_memory_percent)}%'
                     )
             else:
-                device.name = cut_string(device.name, maxlen=19, padstr='..', align='right')
+                device.name = cut_string(
+                    device.name,
+                    maxlen=self._name_maxlen,
+                    padstr='..',
+                    align='right',
+                )
                 device.current_driver_model = device.current_driver_model.replace('WDM', 'TCC')
                 device.display_active = device.display_active.replace('Enabled', 'On').replace(
                     'Disabled',
@@ -224,47 +270,65 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         if compact is None:
             compact = self.compact
 
+        w1 = self._fsw
+        inner = self.base_width - 2
+
         version_infos = [
             'NVITOP {}'.format(__version__.partition('+')[0]),
             f'Driver Version: {self.driver_version}',
             f'CUDA Driver Version: {self.cuda_driver_version}',
         ]
-        if sum(len(v) for v in version_infos) % 2 == 0:
+        if sum(len(v) for v in version_infos) % 2 == (inner + 1) % 2:
             version_infos[0] += ' '
-        version_seps = ' ' * max(2, (75 - sum(len(v) for v in version_infos)) // 2)
+        version_seps = ' ' * max(2, (inner - 2 - sum(len(v) for v in version_infos)) // 2)
 
         header = [
-            '╒═════════════════════════════════════════════════════════════════════════════╕',
-            '│ {} │'.format(version_seps.join(version_infos).ljust(75, ' ')),
+            f'╒{"═" * inner}╕',
+            '│ {} │'.format(version_seps.join(version_infos).ljust(inner - 2, ' ')),
         ]
         if self.device_count > 0:
-            header.append(
-                '├───────────────────────────────┬──────────────────────┬──────────────────────┤',
-            )
+            header.append(f'├{"─" * w1}┬{"─" * 22}┬{"─" * 22}┤')
             if compact:
-                header.append(
-                    '│ GPU Fan Temp Perf Pwr:Usg/Cap │         Memory-Usage │ GPU-Util  Compute M. │',
-                )
+                if self.has_vram_temp:
+                    header.append(
+                        '│ GPU Fan Temp MTmp Perf Pwr:Usg/Cap │'
+                        '         Memory-Usage │ GPU-Util  Compute M. │',
+                    )
+                else:
+                    header.append(
+                        '│ GPU Fan Temp Perf Pwr:Usg/Cap │'
+                        '         Memory-Usage │ GPU-Util  Compute M. │',
+                    )
             else:
-                header.extend(
-                    (
-                        '│ GPU  Name        Persistence-M│ Bus-Id        Disp.A │ Volatile Uncorr. ECC │',
-                        '│ Fan  Temp  Perf  Pwr:Usage/Cap│         Memory-Usage │ GPU-Util  Compute M. │',
-                    ),
-                )
+                if self.has_vram_temp:
+                    header.extend(
+                        (
+                            '│ GPU  Name             Persistence-M│'
+                            ' Bus-Id        Disp.A │ Volatile Uncorr. ECC │',
+                            '│ Fan  Temp MTmp  Perf  Pwr:Usage/Cap│'
+                            '         Memory-Usage │ GPU-Util  Compute M. │',
+                        ),
+                    )
+                else:
+                    header.extend(
+                        (
+                            '│ GPU  Name        Persistence-M│'
+                            ' Bus-Id        Disp.A │ Volatile Uncorr. ECC │',
+                            '│ Fan  Temp  Perf  Pwr:Usage/Cap│'
+                            '         Memory-Usage │ GPU-Util  Compute M. │',
+                        ),
+                    )
                 if IS_WINDOWS:
                     header[-2] = header[-2].replace('Persistence-M', '    TCC/WDDM ')
                 if self.support_mig:
                     header[-2] = header[-2].replace('Volatile Uncorr. ECC', 'MIG M.   Uncorr. ECC')
-            header.append(
-                '╞═══════════════════════════════╪══════════════════════╪══════════════════════╡',
-            )
+            header.append(f'╞{"═" * w1}╪{"═" * 22}╪{"═" * 22}╡')
         else:
             header.extend(
                 (
-                    '╞═════════════════════════════════════════════════════════════════════════════╡',
-                    '│  No visible devices found                                                   │',
-                    '╘═════════════════════════════════════════════════════════════════════════════╛',
+                    f'╞{"═" * inner}╡',
+                    f'│  No visible devices found{" " * (inner - 27)}│',
+                    f'╘{"═" * inner}╛',
                 ),
             )
         return header
@@ -275,14 +339,12 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
         frame = self.header_lines(compact)
 
-        remaining_width = self.width - 79
-        data_line = (
-            '│                               │                      │                      │'
-        )
-        separator_line = (
-            '├───────────────────────────────┼──────────────────────┼──────────────────────┤'
-        )
-        if self.width >= 100:
+        w1 = self._fsw
+        bar_threshold = self.base_width + 21
+        remaining_width = self.width - self.base_width
+        data_line = f'│{" " * w1}│{" " * 22}│{" " * 22}│'
+        separator_line = f'├{"─" * w1}┼{"─" * 22}┼{"─" * 22}┤'
+        if self.width >= bar_threshold:
             data_line += ' ' * (remaining_width - 1) + '│'
             separator_line = separator_line[:-1] + '┼' + '─' * (remaining_width - 1) + '┤'
 
@@ -296,10 +358,8 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                     frame.extend((data_line,) * mig_device_count + (separator_line,))
 
             frame.pop()
-            frame.append(
-                '╘═══════════════════════════════╧══════════════════════╧══════════════════════╛',
-            )
-            if self.width >= 100:
+            frame.append(f'╘{"═" * w1}╧{"═" * 22}╧{"═" * 22}╛')
+            if self.width >= bar_threshold:
                 frame[5 - int(compact)] = (
                     frame[5 - int(compact)][:-1] + '╪' + '═' * (remaining_width - 1) + '╕'
                 )
@@ -320,10 +380,15 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
     def draw(self) -> None:
         self.color_reset()
 
+        bw = self.base_width
+        w1 = self._fsw
+        bar_start = bw + 1
+        bar_threshold = bw + 21
+
         if self.need_redraw:
-            self.addstr(self.y, self.x, '(Press h for help or q to quit)'.rjust(79))
-            self.color_at(self.y, self.x + 55, width=1, fg='magenta', attr='bold | italic')
-            self.color_at(self.y, self.x + 69, width=1, fg='magenta', attr='bold | italic')
+            self.addstr(self.y, self.x, '(Press h for help or q to quit)'.rjust(bw))
+            self.color_at(self.y, self.x + bw - 24, width=1, fg='magenta', attr='bold | italic')
+            self.color_at(self.y, self.x + bw - 10, width=1, fg='magenta', attr='bold | italic')
             for y, line in enumerate(self.frame_lines(), start=self.y + 1):
                 self.addstr(y, self.x, line)
 
@@ -331,8 +396,8 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
         formats = self.formats_compact if self.compact else self.formats_full
 
-        remaining_width = self.width - 79
-        draw_bars = self.width >= 100
+        remaining_width = self.width - bw
+        draw_bars = self.width >= bar_threshold
         try:
             selected_device = self.parent.selection.process.device  # type: ignore[union-attr]
         except AttributeError:
@@ -359,9 +424,9 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
             fmts = self.mig_formats if device.is_mig_device else formats
             for y, fmt in enumerate(fmts, start=y_start):
                 self.addstr(y, self.x, fmt.format(**device.__dict__))
-                self.color_at(y, self.x + 1, width=31, fg=device.display_color, attr=attr)
-                self.color_at(y, self.x + 33, width=22, fg=device.display_color, attr=attr)
-                self.color_at(y, self.x + 56, width=22, fg=device.display_color, attr=attr)
+                self.color_at(y, self.x + 1, width=w1, fg=device.display_color, attr=attr)
+                self.color_at(y, self.x + w1 + 2, width=22, fg=device.display_color, attr=attr)
+                self.color_at(y, self.x + w1 + 25, width=22, fg=device.display_color, attr=attr)
 
             if draw_bars:
                 left_width = (remaining_width - 6 + 1) // 2 - 1
@@ -371,7 +436,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                     matrix = [
                         [
                             (
-                                self.x + 80,
+                                self.x + bar_start,
                                 remaining_width - 3,
                                 'MEM',
                                 device.memory_percent,
@@ -381,13 +446,13 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                         ],
                     ]
                     if remaining_width >= 44 and len(prev_device_index) == 1:
-                        self.addstr(y_start - 1, self.x + 80 + left_width + 1, '┴')
+                        self.addstr(y_start - 1, self.x + bar_start + left_width + 1, '┴')
                 elif self.compact:
                     if remaining_width >= 44:
                         matrix = [
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     left_width,
                                     'MEM',
                                     device.memory_percent,
@@ -395,7 +460,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                                     device.memory_used_human,
                                 ),
                                 (
-                                    self.x + 80 + left_width + 3,
+                                    self.x + bar_start + left_width + 3,
                                     right_width,
                                     'UTL',
                                     device.gpu_utilization,
@@ -407,14 +472,14 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                         separator = '┼' if index > 0 else '╤'
                         if len(prev_device_index) == 2:
                             separator = '┬'
-                        self.addstr(y_start - 1, self.x + 80 + left_width + 1, separator)
+                        self.addstr(y_start - 1, self.x + bar_start + left_width + 1, separator)
                         if index == len(self.snapshots) - 1:
-                            self.addstr(y_start + 1, self.x + 80 + left_width + 1, '╧')
+                            self.addstr(y_start + 1, self.x + bar_start + left_width + 1, '╧')
                     else:
                         matrix = [
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     remaining_width - 3,
                                     'MEM',
                                     device.memory_percent,
@@ -428,7 +493,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                         matrix = [
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     left_width,
                                     'MEM',
                                     device.memory_percent,
@@ -436,7 +501,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                                     device.memory_used_human,
                                 ),
                                 (
-                                    self.x + 80 + left_width + 3,
+                                    self.x + bar_start + left_width + 3,
                                     right_width,
                                     'MBW',
                                     device.memory_utilization,
@@ -446,7 +511,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                             ],
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     left_width,
                                     'UTL',
                                     device.gpu_utilization,
@@ -454,7 +519,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                                     f'@ {device.clock_infos.sm}MHz',
                                 ),
                                 (
-                                    self.x + 80 + left_width + 3,
+                                    self.x + bar_start + left_width + 3,
                                     right_width,
                                     'PWR',
                                     device.power_utilization,
@@ -466,14 +531,14 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                         separator = '┼' if index > 0 else '╤'
                         if len(prev_device_index) == 2:
                             separator = '┬'
-                        self.addstr(y_start - 1, self.x + 80 + left_width + 1, separator)
+                        self.addstr(y_start - 1, self.x + bar_start + left_width + 1, separator)
                         if index == len(self.snapshots) - 1:
-                            self.addstr(y_start + 2, self.x + 80 + left_width + 1, '╧')
+                            self.addstr(y_start + 2, self.x + bar_start + left_width + 1, '╧')
                     else:
                         matrix = [
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     remaining_width - 3,
                                     'MEM',
                                     device.memory_percent,
@@ -483,7 +548,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                             ],
                             [
                                 (
-                                    self.x + 80,
+                                    self.x + bar_start,
                                     remaining_width - 3,
                                     'UTL',
                                     device.gpu_utilization,
@@ -533,12 +598,15 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         self._daemon_running.clear()
 
     def print_width(self) -> int:
-        if self.device_count > 0 and self.width >= 100:
+        if self.device_count > 0 and self.width >= self.base_width + 21:
             return self.width
-        return 79
+        return self.base_width
 
     def print(self) -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         lines = [time.strftime('%a %b %d %H:%M:%S %Y'), *self.header_lines(compact=False)]
+
+        w1 = self._fsw
+        bar_threshold = self.base_width + 21
 
         if self.device_count > 0:
             prev_device_index = self.snapshots[0].tuple_index
@@ -548,7 +616,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                     or prev_device_index[0] != device.tuple_index[0]
                 ):
                     lines.append(
-                        '├───────────────────────────────┼──────────────────────┼──────────────────────┤',
+                        f'├{"─" * w1}┼{"─" * 22}┼{"─" * 22}┤',
                     )
 
                 def colorize(s: str) -> str:
@@ -564,12 +632,10 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
                 prev_device_index = device.tuple_index
 
-            lines.append(
-                '╘═══════════════════════════════╧══════════════════════╧══════════════════════╛',
-            )
+            lines.append(f'╘{"═" * w1}╧{"═" * 22}╧{"═" * 22}╛')
 
-            if self.width >= 100:
-                remaining_width = self.width - 79
+            if self.width >= bar_threshold:
+                remaining_width = self.width - self.base_width
                 y_start = 7
                 prev_device_index = self.snapshots[0].tuple_index
                 for index, device in enumerate(self.snapshots):

--- a/nvitop/tui/screens/main/panels/device.py
+++ b/nvitop/tui/screens/main/panels/device.py
@@ -84,6 +84,7 @@ class DevicePanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         self._snapshot_buffer: list[Snapshot] = []
         self._snapshots: list[Snapshot] = []
         self.snapshot_lock = threading.Lock()
+        self._name_maxlen: int = 19  # default; updated after has_vram_temp is determined
         self.snapshots: list[Snapshot] = self.take_snapshots()
         self._snapshot_daemon = threading.Thread(
             name='device-snapshot-daemon',

--- a/nvitop/tui/screens/main/panels/host.py
+++ b/nvitop/tui/screens/main/panels/host.py
@@ -46,11 +46,14 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         *,
         win: curses.window | None,
         root: TUI,
+        base_width: int = 79,
     ) -> None:
         super().__init__(win, root)
 
         self.devices: list[Device | MigDevice] = devices
         self.device_count: int = len(self.devices)
+        self.base_width: int = base_width
+        self._fsw: int = base_width - 48  # first section width (matches device panel)
 
         if win is not None:
             self.average_gpu_memory_percent: HistoryGraph | None = None
@@ -58,7 +61,7 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
             self.enable_history()
 
         self._compact: bool = compact
-        self.width: int = max(79, root.width)
+        self.width: int = max(self.base_width, root.width)
         self.full_height: int = 12
         self.compact_height: int = 2
         self.height: int = self.compact_height if compact else self.full_height
@@ -80,11 +83,11 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
     @width.setter
     def width(self, value: int) -> None:
-        width = max(79, value)
+        width = max(self.base_width, value)
         if self._width != width:
             if self.visible:
                 self.need_redraw = True
-            graph_width = max(width - 80, 20)
+            graph_width = max(width - self.base_width - 1, 20)
             if self.win is not None:
                 self.average_gpu_memory_percent.width = graph_width  # type: ignore[union-attr]
                 self.average_gpu_utilization.width = graph_width  # type: ignore[union-attr]
@@ -106,9 +109,10 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
             self.height = self.compact_height if self.compact else self.full_height
 
     def enable_history(self) -> None:
+        graph_width = self.base_width - 2
         host.cpu_percent = BufferedHistoryGraph(
             interval=1.0,
-            width=77,
+            width=graph_width,
             height=5,
             upsidedown=False,
             baseline=0.0,
@@ -118,7 +122,7 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         )(host.cpu_percent)
         host.virtual_memory = BufferedHistoryGraph(
             interval=1.0,
-            width=77,
+            width=graph_width,
             height=4,
             upsidedown=True,
             baseline=0.0,
@@ -128,7 +132,7 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         )(host.virtual_memory, get_value=lambda vm: vm.percent)
         host.swap_memory = BufferedHistoryGraph(
             interval=1.0,
-            width=77,
+            width=graph_width,
             height=1,
             upsidedown=False,
             baseline=0.0,
@@ -235,19 +239,24 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         if compact or self.no_unicode:
             return []
 
-        remaining_width = self.width - 79
-        data_line = (
-            '│                                                                             │'
-        )
-        separator_line = (
-            '├────────────╴120s├─────────────────────────╴60s├──────────╴30s├──────────────┤'
-        )
-        if self.width >= 100:
+        bw = self.base_width
+        inner = bw - 2
+        bar_threshold = bw + 21
+        remaining_width = self.width - bw
+        data_line = f'│{" " * inner}│'
+        # Build separator with time markers positioned from the right edge
+        sep_chars = list('─' * inner)
+        for from_right, marker in [(19, '╴30s├'), (34, '╴60s├'), (65, '╴120s├')]:
+            start = inner - from_right
+            if start >= 0 and start + len(marker) <= inner:
+                sep_chars[start : start + len(marker)] = marker
+        separator_line = f'├{"".join(sep_chars)}┤'
+        if self.width >= bar_threshold:
             data_line += ' ' * (remaining_width - 1) + '│'
             separator_line = separator_line[:-1] + '┼' + '─' * (remaining_width - 1) + '┤'
 
         frame = [
-            '╞═══════════════════════════════╧══════════════════════╧══════════════════════╡',
+            f'╞{"═" * self._fsw}╧{"═" * 22}╧{"═" * 22}╡',
             data_line,
             data_line,
             data_line,
@@ -259,9 +268,9 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
             data_line,
             data_line,
             data_line,
-            '╘═════════════════════════════════════════════════════════════════════════════╛',
+            f'╘{"═" * inner}╛',
         ]
-        if self.width >= 100:
+        if self.width >= bar_threshold:
             frame[0] = frame[0][:-1] + '╪' + '═' * (remaining_width - 1) + '╡'
             frame[-1] = frame[-1][:-1] + '╧' + '═' * (remaining_width - 1) + '╛'
 
@@ -324,16 +333,20 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
             )
             return
 
-        remaining_width = self.width - 79
+        bw = self.base_width
+        inner = bw - 2
+        bar_threshold = bw + 21
+        remaining_width = self.width - bw
 
         if self.need_redraw:
             for y, line in enumerate(self.frame_lines(), start=self.y - 1):
                 self.addstr(y, self.x, line)
-            self.color_at(self.y + 5, self.x + 14, width=4, attr='dim')
-            self.color_at(self.y + 5, self.x + 45, width=3, attr='dim')
-            self.color_at(self.y + 5, self.x + 60, width=3, attr='dim')
+            # Highlight the time marker labels in the separator line
+            self.color_at(self.y + 5, self.x + inner - 63, width=4, attr='dim')  # 120s
+            self.color_at(self.y + 5, self.x + inner - 32, width=3, attr='dim')  # 60s
+            self.color_at(self.y + 5, self.x + inner - 17, width=3, attr='dim')  # 30s
 
-            if self.width >= 100:
+            if self.width >= bar_threshold:
                 for offset, string in (
                     (20, '╴30s├'),
                     (35, '╴60s├'),
@@ -364,7 +377,7 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
         for y, line in enumerate(host.swap_memory.history.graph, start=self.y + 10):  # type: ignore[attr-defined]
             self.addstr(y, self.x + 1, line)
 
-        if self.width >= 100:
+        if self.width >= bar_threshold:
             if self.device_count > 1 and self.parent.selection.is_set():
                 device = self.parent.selection.process.device  # type: ignore[union-attr]
                 gpu_memory_percent = device.memory_percent.history  # type: ignore[union-attr]
@@ -375,18 +388,18 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
 
             if self.TERM_256COLOR:
                 for i, (y, line) in enumerate(enumerate(gpu_memory_percent.graph, start=self.y)):
-                    self.addstr(y, self.x + 79, line, self.get_fg_bg_attr(fg=1.0 - i / 4.0))
+                    self.addstr(y, self.x + bw, line, self.get_fg_bg_attr(fg=1.0 - i / 4.0))
 
                 for i, (y, line) in enumerate(enumerate(gpu_utilization.graph, start=self.y + 6)):
-                    self.addstr(y, self.x + 79, line, self.get_fg_bg_attr(fg=i / 4.0))
+                    self.addstr(y, self.x + bw, line, self.get_fg_bg_attr(fg=i / 4.0))
             else:
                 self.color(fg=Device.color_of(gpu_memory_percent.last_value, type='memory'))
                 for y, line in enumerate(gpu_memory_percent.graph, start=self.y):
-                    self.addstr(y, self.x + 79, line)
+                    self.addstr(y, self.x + bw, line)
 
                 self.color(fg=Device.color_of(gpu_utilization.last_value, type='gpu'))
                 for y, line in enumerate(gpu_utilization.graph, start=self.y + 6):
-                    self.addstr(y, self.x + 79, line)
+                    self.addstr(y, self.x + bw, line)
 
         self.color_reset()
         self.addstr(self.y, self.x + 1, f' {load_average} ')
@@ -407,18 +420,18 @@ class HostPanel(BasePanel):  # pylint: disable=too-many-instance-attributes
                 f'({host.swap_memory.history}) '  # type: ignore[attr-defined]
             ),
         )
-        if self.width >= 100:
-            self.addstr(self.y, self.x + 79, f' {gpu_memory_percent} ')
-            self.addstr(self.y + 10, self.x + 79, f' {gpu_utilization} ')
+        if self.width >= bar_threshold:
+            self.addstr(self.y, self.x + bw, f' {gpu_memory_percent} ')
+            self.addstr(self.y + 10, self.x + bw, f' {gpu_utilization} ')
 
     def destroy(self) -> None:
         super().destroy()
         self._daemon_running.clear()
 
     def print_width(self) -> int:
-        if self.device_count > 0 and self.width >= 100:
+        if self.device_count > 0 and self.width >= self.base_width + 21:
             return self.width
-        return 79
+        return self.base_width
 
     def print(self) -> None:
         self.cpu_percent = host.cpu_percent()


### PR DESCRIPTION
## Summary

- Add GDDR6/GDDR6X VRAM (memory junction) temperature reading via direct GPU BAR0 register access through `/dev/mem`
- New `Device.vram_temperature()` API method returning temperature in Celsius or `NA`
- Conditional "MTmp" column in TUI device panel — only shown when at least one GPU reports VRAM temperature data, preserving the original 79-column layout otherwise
- Supports ~23 NVIDIA GPU models (RTX 30xx/40xx series + select data center cards like A10, L4, L40S)

## Requirements

- **Linux only** (uses `/dev/mem` and sysfs)
- **Root access** required
- **`iomem=relaxed`** kernel parameter required
- Gracefully returns `N/A` when any requirement is not met — no errors, no crashes

## Implementation details

- `nvitop/api/libgddr6.py`: New module with thread-safe singleton context, mmap caching, and PCI device table mapping device IDs to BAR0 register offsets
- `nvitop/api/device.py`: `vram_temperature()` method with lazy import to avoid `/dev/mem` access at import time
- `nvitop/tui/screens/main/panels/device.py`: Conditional layout — detects VRAM temp availability at init, selects between 79-col (standard) and 84-col (with MTmp) layouts. All width constants parameterized via `base_width`
- `nvitop/tui/screens/main/panels/host.py`: Accepts dynamic `base_width` to match device panel

## Attribution

Ported from [olealgoritme/gddr6](https://github.com/olealgoritme/gddr6) (C implementation).

## Test plan

- [ ] Run `sudo python -m nvitop` on a supported GPU — verify MTmp column appears with temperatures
- [ ] Run `python -m nvitop` as non-root — verify original 79-col layout with no MTmp column
- [ ] Verify `from nvitop import Device; d = Device(0); print(d.vram_temperature())` returns int or NA
- [ ] Verify box-drawing characters align correctly in both layout modes
- [ ] Run `ruff check` and `ruff format --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)