### PR TITLE
fix(api/libnvml): drain in-flight NVML queries before atexit shutdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         args: [--ignore-case]
         files: ^docs/source/spelling_wordlist\.txt$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.21
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -41,7 +41,7 @@ repos:
       - id: codespell
         additional_dependencies: [".[toml]"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
       - id: mypy
         exclude: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix an intermittent `SIGSEGV` at interpreter exit where the `atexit` `nvmlShutdown()` raced in-flight NVML queries from background threads by [@XuehaiPan](https://github.com/XuehaiPan) in [#223](https://github.com/XuehaiPan/nvitop/pull/223). Issued by [@zengchang233](https://github.com/zengchang233) in [#222](https://github.com/XuehaiPan/nvitop/issues/222).
 
 ### Removed
 

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -231,6 +231,8 @@ __shutdown_lock: _threading.Lock = _threading.Lock()
 __active_queries: int = 0
 # Once set on shutdown, no new NVML queries are issued; never reset to False.
 __shutting_down: bool = False
+# Whether the `atexit` shutdown hook has been registered (registered at most once per process).
+__atexit_registered: bool = False
 
 LOGGER: _logging.Logger = _logging.getLogger(__name__)
 try:
@@ -269,6 +271,8 @@ def _lazy_init() -> None:
             If cannot find function :func:`pynvml.nvmlInitWithFlags`, usually the :mod:`pynvml` module
             is overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
     """
+    global __atexit_registered  # pylint: disable=global-statement
+
     if __initialized or __shutting_down:
         return
 
@@ -277,7 +281,13 @@ def _lazy_init() -> None:
             return  # type: ignore[unreachable]
 
     nvmlInit()
-    _atexit.register(_atexit_shutdown, timeout=120.0)
+
+    # Register the shutdown hook exactly once: concurrent first initialization and repeated
+    # initialization/shutdown cycles must not queue duplicate `atexit` handlers.
+    with __lock:
+        if not __atexit_registered:
+            _atexit.register(_atexit_shutdown, timeout=120.0)
+            __atexit_registered = True
 
 
 def _atexit_shutdown(timeout: float | None = None) -> None:
@@ -297,7 +307,9 @@ def _atexit_shutdown(timeout: float | None = None) -> None:
 
     .. note::
         This only guards the implicit ``atexit`` shutdown. An explicit :func:`nvmlShutdown` call
-        (e.g. to reinitialize NVML) is unaffected and remains the caller's responsibility.
+        (e.g. to reinitialize NVML) is unaffected and remains the caller's responsibility. The drain
+        only tracks NVML calls made through :func:`nvmlQuery`; direct :mod:`pynvml` calls are not
+        counted.
     """
     global __shutting_down  # pylint: disable=global-statement
 
@@ -316,7 +328,12 @@ def _atexit_shutdown(timeout: float | None = None) -> None:
         with __shutdown_lock:
             drained = __active_queries == 0
         if drained:
-            nvmlShutdown()
+            try:
+                nvmlShutdown()
+            except NVMLError:
+                # NVML may already be torn down (e.g. via an explicit `nvmlShutdown()` call); the
+                # OS reclaims all NVML resources at process exit regardless.
+                pass
             return
         if endtime is not None and _time.monotonic() >= endtime:
             # Timed out with queries still in flight: skip `nvmlShutdown()` to avoid a

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -339,6 +339,28 @@ def _atexit_shutdown(timeout: float | None = None) -> None:
         LOGGER.warning('Skipped `nvmlShutdown()` at exit: NVML queries are still in flight.')
 
 
+def _reset_after_fork() -> None:
+    """Reset the NVML shutdown-drain state in a forked child process.
+
+    ``os.fork()`` copies the module globals but leaves only the calling thread alive in the child:
+    a lock held by another thread at fork time is inherited already-locked, and ``__active_queries``
+    may count queries owned by threads that no longer exist. Rebuild the synchronization primitives
+    and zero the drain state so the child starts clean; otherwise the inherited ``atexit`` hook
+    could block for its full timeout draining phantom queries, or deadlock on an inherited-locked
+    ``Lock``.
+    """
+    global __lock, __shutdown_condition, __active_queries, __shutting_down  # pylint: disable=global-statement
+
+    __lock = _threading.Lock()
+    __shutdown_condition = _threading.Condition()
+    __active_queries = 0
+    __shutting_down = False
+
+
+if hasattr(_os, 'register_at_fork'):  # `os.register_at_fork` is unavailable on Windows (no `fork`)
+    _os.register_at_fork(after_in_child=_reset_after_fork)
+
+
 def nvmlInit() -> None:  # pylint: disable=function-redefined
     """Initialize the NVML context with default flag (0).
 

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -184,6 +184,7 @@ else:
 c_nvmlFieldValue_t: _TypeAlias = _pynvml.c_nvmlFieldValue_t  # noqa: PYI042
 NVML_SUCCESS: int = _pynvml.NVML_SUCCESS
 NVML_ERROR_INSUFFICIENT_SIZE: int = _pynvml.NVML_ERROR_INSUFFICIENT_SIZE
+NVMLError_Uninitialized: _TypeAlias = _pynvml.NVMLError_Uninitialized
 NVMLError_FunctionNotFound: _TypeAlias = _pynvml.NVMLError_FunctionNotFound
 NVMLError_GpuIsLost: _TypeAlias = _pynvml.NVMLError_GpuIsLost
 NVMLError_InvalidArgument: _TypeAlias = _pynvml.NVMLError_InvalidArgument
@@ -227,7 +228,7 @@ NVML_VALUE_TYPE_SIGNED_INT: int = getattr(_pynvml, 'NVML_VALUE_TYPE_SIGNED_INT',
 __flags: list[int] = []
 __initialized: bool = False
 __lock: _threading.Lock = _threading.Lock()
-__shutdown_lock: _threading.Lock = _threading.Lock()
+__shutdown_condition: _threading.Condition = _threading.Condition()
 __active_queries: int = 0
 # Once set on shutdown, no new NVML queries are issued; never reset to False.
 __shutting_down: bool = False
@@ -316,31 +317,26 @@ def _atexit_shutdown(timeout: float | None = None) -> None:
     if __shutting_down:
         return
 
-    with __shutdown_lock:
+    # Set the shutdown latch, then wait for in-flight queries to drain. Once `__shutting_down` is
+    # set, `nvmlQuery` starts no new NVML calls, so `__active_queries` only decreases; each decrement
+    # notifies the condition, so this blocks without polling and wakes as soon as it reaches zero.
+    with __shutdown_condition:
         if __shutting_down:
             return  # type: ignore[unreachable]
         __shutting_down = True
+        drained = __shutdown_condition.wait_for(lambda: __active_queries == 0, timeout=timeout)
 
-    # Once `__shutting_down` is set, `nvmlQuery` starts no new NVML calls, so `__active_queries`
-    # only decreases -- wait for it to reach zero before freeing the NVML context.
-    endtime = None if timeout is None else _time.monotonic() + timeout
-    while True:
-        with __shutdown_lock:
-            drained = __active_queries == 0
-        if drained:
-            try:
-                nvmlShutdown()
-            except NVMLError:
-                # NVML may already be torn down (e.g. via an explicit `nvmlShutdown()` call); the
-                # OS reclaims all NVML resources at process exit regardless.
-                pass
-            return
-        if endtime is not None and _time.monotonic() >= endtime:
-            # Timed out with queries still in flight: skip `nvmlShutdown()` to avoid a
-            # use-after-free. The OS reclaims all NVML resources at process exit anyway.
-            LOGGER.warning('Skipped `nvmlShutdown()` at exit: NVML queries are still in flight.')
-            return
-        _time.sleep(0.001)
+    if drained:
+        try:
+            nvmlShutdown()
+        except NVMLError:
+            # NVML may already be torn down (e.g. via an explicit `nvmlShutdown()` call); the OS
+            # reclaims all NVML resources at process exit regardless.
+            pass
+    else:
+        # Timed out with queries still in flight: skip `nvmlShutdown()` to avoid a use-after-free.
+        # The OS reclaims all NVML resources at process exit anyway.
+        LOGGER.warning('Skipped `nvmlShutdown()` at exit: NVML queries are still in flight.')
 
 
 def nvmlInit() -> None:  # pylint: disable=function-redefined
@@ -502,57 +498,73 @@ def nvmlQuery(
     global UNKNOWN_FUNCTIONS, __active_queries  # pylint: disable=global-statement,global-variable-not-assigned
 
     if __shutting_down:
-        return default  # return early on interpreter shutdown to avoid re-initializing
+        if ignore_errors:
+            return default
+        raise NVMLError_Uninitialized
 
-    _lazy_init()
-
-    with __shutdown_lock:
+    # Reserve an in-flight slot BEFORE any NVML-touching work (including `_lazy_init`'s `nvmlInit`)
+    # so the `atexit` drain waits for this query instead of shutting NVML down underneath it.
+    # See https://github.com/XuehaiPan/nvitop/issues/222.
+    with __shutdown_condition:
         if __shutting_down:
-            return default  # type: ignore[unreachable]
+            if ignore_errors:  # type: ignore[unreachable]
+                return default
+            raise NVMLError_Uninitialized
         __active_queries += 1
 
     try:
-        if isinstance(func, str):
-            try:
-                func = getattr(__modself, func)
-            except AttributeError as e1:
-                raise NVMLError_FunctionNotFound from e1
+        _lazy_init()
+
+        # Re-check after `_lazy_init`: shutdown may have started while we initialized, in which case
+        # `_lazy_init` bailed and NVML is not up -- abort before calling an uninitialized function.
+        if __shutting_down:
+            if ignore_errors:  # type: ignore[unreachable]
+                return default
+            raise NVMLError_Uninitialized
 
         try:
-            retval = func(*args, **kwargs)
-        except UnicodeDecodeError as e2:
-            raise NVMLError_Unknown from e2
-    except NVMLError_FunctionNotFound as e3:
-        if not ignore_function_not_found:
-            identifier = (
-                func
-                if isinstance(func, str)
-                else (_inspect.getsource(func) if func.__name__ == '<lambda>' else repr(func))
-            )
-            with __lock:
-                if (
-                    identifier not in UNKNOWN_FUNCTIONS
-                    and len(UNKNOWN_FUNCTIONS) < UNKNOWN_FUNCTIONS_CACHE_SIZE
-                ):
-                    UNKNOWN_FUNCTIONS[identifier] = (func, e3)
-                    LOGGER.exception(
-                        (
-                            'ERROR: A FunctionNotFound error occurred while calling %s.\n'
-                            'Please verify whether the `nvidia-ml-py` package is '
-                            'compatible with your NVIDIA driver version.'
-                        ),
-                        f'nvmlQuery({func!r}, *args, **kwargs)',
-                    )
-        if ignore_errors or ignore_function_not_found:
-            return default
-        raise
-    except NVMLError:
-        if ignore_errors:
-            return default
-        raise
+            if isinstance(func, str):
+                try:
+                    func = getattr(__modself, func)
+                except AttributeError as e1:
+                    raise NVMLError_FunctionNotFound from e1
+
+            try:
+                retval = func(*args, **kwargs)
+            except UnicodeDecodeError as e2:
+                raise NVMLError_Unknown from e2
+        except NVMLError_FunctionNotFound as e3:
+            if not ignore_function_not_found:
+                identifier = (
+                    func
+                    if isinstance(func, str)
+                    else (_inspect.getsource(func) if func.__name__ == '<lambda>' else repr(func))
+                )
+                with __lock:
+                    if (
+                        identifier not in UNKNOWN_FUNCTIONS
+                        and len(UNKNOWN_FUNCTIONS) < UNKNOWN_FUNCTIONS_CACHE_SIZE
+                    ):
+                        UNKNOWN_FUNCTIONS[identifier] = (func, e3)
+                        LOGGER.exception(
+                            (
+                                'ERROR: A FunctionNotFound error occurred while calling %s.\n'
+                                'Please verify whether the `nvidia-ml-py` package is '
+                                'compatible with your NVIDIA driver version.'
+                            ),
+                            f'nvmlQuery({func!r}, *args, **kwargs)',
+                        )
+            if ignore_errors or ignore_function_not_found:
+                return default
+            raise
+        except NVMLError:
+            if ignore_errors:
+                return default
+            raise
     finally:
-        with __shutdown_lock:
+        with __shutdown_condition:
             __active_queries -= 1
+            __shutdown_condition.notify_all()
 
     if isinstance(retval, bytes):
         retval = retval.decode('utf-8', errors='replace')

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -230,7 +230,8 @@ __initialized: bool = False
 __lock: _threading.Lock = _threading.Lock()
 __shutdown_condition: _threading.Condition = _threading.Condition()
 __active_queries: int = 0
-# Once set on shutdown, no new NVML queries are issued; never reset to False.
+# Set on shutdown to stop issuing new NVML queries; stays set for the life of the process, except a
+# forked child resets it to False via `_reset_after_fork`.
 __shutting_down: bool = False
 # Whether the `atexit` shutdown hook has been registered (registered at most once per process).
 __atexit_registered: bool = False
@@ -516,6 +517,10 @@ def nvmlQuery(
             If the function is not supported by the driver or the device.
         NVMLError_InvalidArgument:
             If passed with an invalid argument.
+        NVMLError_Uninitialized:
+            If a shutdown is in progress (the ``atexit`` drain latch is set) and ``ignore_errors``
+            is :data:`False`. New NVML calls are refused once shutdown begins so they cannot race
+            :func:`nvmlShutdown`.
     """
     global UNKNOWN_FUNCTIONS, __active_queries  # pylint: disable=global-statement,global-variable-not-assigned
 

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -269,11 +269,11 @@ def _lazy_init() -> None:
             If cannot find function :func:`pynvml.nvmlInitWithFlags`, usually the :mod:`pynvml` module
             is overridden by other modules. Need to reinstall package ``nvidia-ml-py``.
     """
-    if __initialized:
+    if __initialized or __shutting_down:
         return
 
     with __lock:
-        if __initialized:
+        if __initialized or __shutting_down:
             return  # type: ignore[unreachable]
 
     nvmlInit()
@@ -301,7 +301,12 @@ def _atexit_shutdown(timeout: float | None = None) -> None:
     """
     global __shutting_down  # pylint: disable=global-statement
 
+    if __shutting_down:
+        return
+
     with __shutdown_lock:
+        if __shutting_down:
+            return  # type: ignore[unreachable]
         __shutting_down = True
 
     # Once `__shutting_down` is set, `nvmlQuery` starts no new NVML calls, so `__active_queries`
@@ -479,10 +484,10 @@ def nvmlQuery(
     """
     global UNKNOWN_FUNCTIONS, __active_queries  # pylint: disable=global-statement,global-variable-not-assigned
 
-    _lazy_init()
-
     if __shutting_down:
-        return default
+        return default  # return early on interpreter shutdown to avoid re-initializing
+
+    _lazy_init()
 
     with __shutdown_lock:
         if __shutting_down:

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -227,6 +227,10 @@ NVML_VALUE_TYPE_SIGNED_INT: int = getattr(_pynvml, 'NVML_VALUE_TYPE_SIGNED_INT',
 __flags: list[int] = []
 __initialized: bool = False
 __lock: _threading.Lock = _threading.Lock()
+__shutdown_lock: _threading.Lock = _threading.Lock()
+__active_queries: int = 0
+# Once set on shutdown, no new NVML queries are issued; never reset to False.
+__shutting_down: bool = False
 
 LOGGER: _logging.Logger = _logging.getLogger(__name__)
 try:
@@ -273,7 +277,48 @@ def _lazy_init() -> None:
             return  # type: ignore[unreachable]
 
     nvmlInit()
-    _atexit.register(nvmlShutdown)
+    _atexit.register(_atexit_shutdown, timeout=120.0)
+
+
+def _atexit_shutdown(timeout: float | None = None) -> None:
+    """Wait for in-flight NVML queries, then shutdown the NVML context (registered via ``atexit``).
+
+    Setting ``__shutting_down`` makes :func:`nvmlQuery` stop issuing new NVML calls, and the drain
+    loop waits for any in-flight query to finish before calling :func:`nvmlShutdown`. This keeps
+    :func:`nvmlShutdown` from freeing NVML internal state while a background thread is still inside
+    a ``libnvidia-ml`` call -- an intermittent use-after-free that segfaults on interpreter exit.
+
+    Args:
+        timeout (Optional[float]):
+            The maximum number of seconds to wait for in-flight queries to drain.
+            :data:`None` (the default) waits indefinitely. If the queries do not drain within
+            ``timeout``, :func:`nvmlShutdown` is skipped to avoid a use-after-free; the OS reclaims
+            NVML resources at process exit anyway.
+
+    .. note::
+        This only guards the implicit ``atexit`` shutdown. An explicit :func:`nvmlShutdown` call
+        (e.g. to reinitialize NVML) is unaffected and remains the caller's responsibility.
+    """
+    global __shutting_down  # pylint: disable=global-statement
+
+    with __shutdown_lock:
+        __shutting_down = True
+
+    # Once `__shutting_down` is set, `nvmlQuery` starts no new NVML calls, so `__active_queries`
+    # only decreases -- wait for it to reach zero before freeing the NVML context.
+    endtime = None if timeout is None else _time.monotonic() + timeout
+    while True:
+        with __shutdown_lock:
+            drained = __active_queries == 0
+        if drained:
+            nvmlShutdown()
+            return
+        if endtime is not None and _time.monotonic() >= endtime:
+            # Timed out with queries still in flight: skip `nvmlShutdown()` to avoid a
+            # use-after-free. The OS reclaims all NVML resources at process exit anyway.
+            LOGGER.warning('Skipped `nvmlShutdown()` at exit: NVML queries are still in flight.')
+            return
+        _time.sleep(0.001)
 
 
 def nvmlInit() -> None:  # pylint: disable=function-redefined
@@ -386,6 +431,7 @@ def nvmlShutdown() -> None:  # pylint: disable=function-redefined
         __initialized = len(__flags) > 0
 
 
+# pylint: disable-next=too-many-branches
 def nvmlQuery(
     func: _Callable[..., _Any] | str,
     /,
@@ -431,9 +477,17 @@ def nvmlQuery(
         NVMLError_InvalidArgument:
             If passed with an invalid argument.
     """
-    global UNKNOWN_FUNCTIONS  # pylint: disable=global-statement,global-variable-not-assigned
+    global UNKNOWN_FUNCTIONS, __active_queries  # pylint: disable=global-statement,global-variable-not-assigned
 
     _lazy_init()
+
+    if __shutting_down:
+        return default
+
+    with __shutdown_lock:
+        if __shutting_down:
+            return default  # type: ignore[unreachable]
+        __active_queries += 1
 
     try:
         if isinstance(func, str):
@@ -474,6 +528,9 @@ def nvmlQuery(
         if ignore_errors:
             return default
         raise
+    finally:
+        with __shutdown_lock:
+            __active_queries -= 1
 
     if isinstance(retval, bytes):
         retval = retval.decode('utf-8', errors='replace')


### PR DESCRIPTION
#### Issue Type

- Bug fix

#### Runtime Environment

<!-- Verified on a Linux host with 4x NVIDIA H100 80GB GPUs; the affected environment from #222 is listed below. -->

- Operating system and version: Ubuntu 24.04.3 LTS (x86_64) — affected environment from #222; also verified on another Linux x86_64 host
- Terminal emulator and version: N/A (the race is independent of the terminal emulator)
- Python version: `3.14.6` (reporter) / `3.12.3` (verification host)
- NVML version (driver version): `580.126.20`
- `nvitop` version or commit: `fix/nvml-shutdown-drain@b0821c6`
- `python-ml-py` version: `13.595.45`
- Locale: N/A

#### Description

Pressing <kbd>q</kbd> to quit the TUI intermittently crashed with a `SIGSEGV` inside `libnvidia-ml`. The `atexit` `nvmlShutdown()` could free NVML internal state while a background thread was still inside a `libnvidia-ml` call — a use-after-free. This affects any concurrent NVML user of `nvitop.api`, including the TUI snapshot daemons and the reproducer in #222 (which spawns query threads with no TUI involved).

The fix makes the implicit `atexit` shutdown safe rather than dropping it, by draining in-flight queries before the shutdown. All changes are confined to `nvitop/api/libnvml.py` and to nvitop's own additions on top of `pynvml` — the re-exported `pynvml` API is left untouched.

**Drain in-flight queries at `atexit`:**

- `nvmlQuery` bails on an unlocked `__shutting_down` fast path, then reserves an in-flight slot — incrementing `__active_queries` under a `threading.Condition` — **before** any NVML-touching work (including lazy `nvmlInit`), and re-checks `__shutting_down` after initialization. The NVML call itself runs outside the lock, so concurrent NVML access is never serialized; the slot is released and the condition notified in a `finally`.
- `_atexit_shutdown` sets the one-way `__shutting_down` latch, then waits on the condition for `__active_queries` to reach zero before calling `nvmlShutdown()`. Once the latch is set no new query starts, so the counter only decreases and the wait wakes on the last decrement (event-driven, not polling). The wait is bounded (120 s) and skips `nvmlShutdown()` if queries do not drain in time — the OS reclaims NVML resources at process exit anyway.

**Reset the drain state across `os.fork()`:**

- `os.fork()` copies the module globals but leaves only the calling thread alive in the child, so the child can inherit a non-zero `__active_queries` (a query owned by a thread that no longer exists) or an already-held internal lock — making the inherited `atexit` hook block for its full timeout, or deadlock. `_reset_after_fork`, registered via `os.register_at_fork(after_in_child=...)`, rebuilds the lock/condition and zeroes the drain state in the child (guarded with `hasattr(os, 'register_at_fork')` since it is unavailable on Windows).

The re-exported `pynvml` API is unchanged: `nvmlShutdown()` keeps its original signature, and an explicit `nvmlShutdown()` — or a raw `libnvml.nvml*` call — racing in-flight queries remains the caller's responsibility, since the drain only tracks calls made through `nvmlQuery`.

The `chore(pre-commit)` commit bumps the `ruff` and `mypy` pre-commit hooks.

#### Motivation and Context

Fixes #222.

Root cause: the `atexit` `nvmlShutdown()` races with in-flight NVML calls from background threads still running at interpreter exit; the shutdown frees NVML internal state under a concurrent call. Draining in-flight `nvmlQuery` calls before the shutdown closes the race for **any** concurrent caller — including the no-TUI reproducer in the issue, which a TUI-level fix could not help.

#### Testing

Verified on a Linux host with 4× NVIDIA H100 80 GB GPUs (Python 3.12.3) using the `nvml_race.py` reproducer from #222, run 25 times per build:

| Build | `nvml_race.py` × 25 |
| --- | --- |
| `main` (no fix) | **15 / 25 `SIGSEGV`** (`rc=139`) |
| `fix/nvml-shutdown-drain` | **0 / 25** |

```console
$ git switch main
$ python3 nvml_race.py
[1]    920641 segmentation fault (core dumped)  python3 nvml_race.py

$ git switch fix/nvml-shutdown-drain
$ python3 nvml_race.py
$   # exits cleanly, no coredump
```

- On `main` the reproducer segfaults on ~60% of runs; on this branch it never crashes across 25 runs.
- The crash is Linux-specific: on Windows, `main` does not coredump.
- The `os.fork()` reset was verified GPU-free with a real `fork()`: a child that inherits a non-zero in-flight counter is reset to zero by the registered hook, so its `atexit` drain returns immediately instead of blocking for the timeout.
- The coordination logic was also checked GPU-free during development: `nvmlQuery` refuses new NVML calls once `__shutting_down` is set, and `_atexit_shutdown` waits for an in-flight query before calling `nvmlShutdown()`.
- `pre-commit` (ruff, ruff-format, codespell, mypy, pylint) passes. No automated tests are included (the repository has no test harness yet).
