### PR TITLE
feat(examples): enrich the colored monitor and support uv run from a URL

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -137,6 +137,7 @@ superset
 sys
 systemd
 tcc
+tensorboard
 tensorflow
 throughputinfo
 toml
@@ -155,6 +156,7 @@ unparsable
 uptime
 utils
 uuid
+uv
 wddm
 wdm
 widestring

--- a/examples/collector-background/README.md
+++ b/examples/collector-background/README.md
@@ -16,6 +16,12 @@ The same pattern is available as a one-liner via [`ResourceMetricCollector.daemo
 python3 examples/collector-background/collector_background.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-background/collector_background.py
+```
+
 The script collects in the background for ~10 seconds and prints each tick.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/collector-background/collector_background.py
+++ b/examples/collector-background/collector_background.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Run `ResourceMetricCollector` on a background daemon thread via `collect_in_background`."""
+"""Run `ResourceMetricCollector` on a background daemon thread via `collect_in_background`.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-background/collector_background.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/collector-csv/README.md
+++ b/examples/collector-csv/README.md
@@ -13,6 +13,12 @@ pip install -r examples/collector-csv/requirements.txt
 python3 examples/collector-csv/collector_csv.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv) (which installs the dependencies automatically):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-csv/collector_csv.py
+```
+
 By default the script takes 5 samples at 2-second intervals (≈10s wall time). Bump the `SAMPLES` / `SAMPLE_INTERVAL_SECONDS` constants at the top of the file for a longer run.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/collector-csv/collector_csv.py
+++ b/examples/collector-csv/collector_csv.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Sample resource metrics with `ResourceMetricCollector` and append to a CSV file."""
+"""Sample resource metrics with `ResourceMetricCollector` and append to a CSV file.
+
+Run without cloning the repository using ``uv`` (which installs the dependencies automatically)::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-csv/collector_csv.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop", "pandas"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/collector-tensorboard/README.md
+++ b/examples/collector-tensorboard/README.md
@@ -14,6 +14,12 @@ pip install -r examples/collector-tensorboard/requirements.txt
 python3 examples/collector-tensorboard/collector_tensorboard.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv) (which installs the dependencies automatically):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-tensorboard/collector_tensorboard.py
+```
+
 The script writes a [TensorBoard] event file under `runs/` and prints the location at the end. View it with `tensorboard --logdir runs`.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/collector-tensorboard/collector_tensorboard.py
+++ b/examples/collector-tensorboard/collector_tensorboard.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Log `ResourceMetricCollector` output to TensorBoard alongside a tiny training loop."""
+"""Log `ResourceMetricCollector` output to TensorBoard alongside a tiny training loop.
+
+Run without cloning the repository using ``uv`` (which installs the dependencies automatically)::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/collector-tensorboard/collector_tensorboard.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop", "torch", "tensorboard"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/monitor-colored/README.md
+++ b/examples/monitor-colored/README.md
@@ -1,12 +1,13 @@
 # Colored GPU Monitor
 
-A richer version of the minimal monitor that uses [`nvitop.colored`][colored] to highlight device names, sections, and column headers, plus per-process snapshots taken via [`GpuProcess.take_snapshots`][take-snapshots].
+A richer version of the minimal monitor. Uses [`nvitop.colored`][colored] to highlight the device name, field labels, and column headers, and adds a host summary line (CPU, memory, swap, and load average), a two-column device panel, and per-process snapshots taken via [`GpuProcess.take_snapshots`][take-snapshots].
 
 ## APIs Used
 
-- [`nvitop.CudaDevice.all()`][cuda-all]
-- [`nvitop.GpuProcess.take_snapshots`][take-snapshots]
-- [`nvitop.colored`][colored], [`nvitop.NA`][na]
+- [`nvitop.CudaDevice.all()`][cuda-all] and [`nvitop.GpuProcess.take_snapshots`][take-snapshots]
+- [`nvitop.host`][host] for host metrics (`cpu_percent`, `virtual_memory`, `swap_memory`, `load_average`, `hostname`, `getuser`)
+- [`nvitop.bytes2human`][bytes2human] to format host memory sizes
+- [`nvitop.colored`][colored] and [`nvitop.NA`][na]
 
 ## Run
 
@@ -18,7 +19,9 @@ Requires only `nvitop` itself; no other dependencies.
 
 See [`../README.md`](../README.md) for the full example index.
 
+[bytes2human]: https://nvitop.readthedocs.io/en/latest/api/utils.html#nvitop.bytes2human
 [colored]: https://nvitop.readthedocs.io/en/latest/api/utils.html#nvitop.colored
 [cuda-all]: https://nvitop.readthedocs.io/en/latest/api/device.html#nvitop.CudaDevice.all
+[host]: https://nvitop.readthedocs.io/en/latest/api/host.html
 [na]: https://nvitop.readthedocs.io/en/latest/api/utils.html#nvitop.NA
 [take-snapshots]: https://nvitop.readthedocs.io/en/latest/api/process.html#nvitop.GpuProcess.take_snapshots

--- a/examples/monitor-colored/README.md
+++ b/examples/monitor-colored/README.md
@@ -15,6 +15,12 @@ A richer version of the minimal monitor. Uses [`nvitop.colored`][colored] to hig
 python3 examples/monitor-colored/monitor_colored.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-colored/monitor_colored.py
+```
+
 Requires only `nvitop` itself; no other dependencies.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/monitor-colored/monitor_colored.py
+++ b/examples/monitor-colored/monitor_colored.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import time
 
-from nvitop import NA, CudaDevice, GpuProcess, colored
+from nvitop import NA, CudaDevice, GpuProcess, bytes2human, colored, host
 
 
 def label(text: str) -> str:
@@ -28,32 +28,108 @@ def label(text: str) -> str:
     return colored(text, color='blue', attrs=('bold',))
 
 
+def field(name: str, value: object, unit: str = '', *, width: int = 20, pad: int = 0) -> str:
+    """Render a colored ``- label: value`` field; an unavailable value drops its unit."""
+    text = str(value) if value is NA else f'{value}{unit}'  # keep a bare `N/A`, never `N/A%`
+    prefix = label(f'- {name}:'.ljust(width))
+    return f'{prefix} {text.ljust(pad)}' if pad else f'{prefix} {text}'
+
+
+def cpu_percent_text(value: object) -> str:
+    """Format a CPU percentage that may exceed 100% (multi-threaded), matching how nvitop rounds it."""
+    if not isinstance(value, (int, float)):
+        return 'N/A'  # value is NA or otherwise unavailable
+    if value < 1000.0:
+        return f'{value:.1f}'  # e.g. 3.0, 282.7 — one decimal keeps 100%+ readable
+    if value < 10000.0:
+        return str(int(value))  # e.g. 1234 — drop the decimal to fit the column
+    return '9999+'
+
+
+def host_summary() -> str:
+    """Build a one-line host summary: CPU, memory, swap, and load average."""
+    cpu = host.cpu_percent(interval=0.1)  # interval forces a fresh sample; a bare call reads 0.0%
+    virtual_memory = host.virtual_memory()
+    swap_memory = host.swap_memory()
+    # `load_average()` returns a 3-tuple of floats, or None on platforms without `getloadavg`.
+    load_average: tuple[float, float, float] | None = host.load_average()
+    load = 'N/A' if load_average is None else ' '.join(f'{value:.2f}' for value in load_average)
+    stats = ' | '.join(
+        (
+            f'CPU {cpu:.1f}%',
+            (
+                f'Memory {bytes2human(virtual_memory.used)} / {bytes2human(virtual_memory.total)}'
+                f' ({virtual_memory.percent:.1f}%)'
+            ),
+            f'Swap {bytes2human(swap_memory.used)} / {bytes2human(swap_memory.total)}',
+            f'Load {load}',
+        ),
+    )
+    host_label = colored('[Host]', color='yellow', attrs=('bold',))
+    return f'{host_label} {stats}'
+
+
+def device_header(device: CudaDevice) -> str:
+    """Build the colored device header: green index tag, white device name, green total memory."""
+    index_tag = colored(
+        f'[CUDA {device.cuda_index} / NVML {device.physical_index}]',
+        color='green',
+        attrs=('bold',),
+    )
+    name_tag = colored(device.name(), color='white', attrs=('bold',))
+    memory_tag = colored(f'({device.memory_total_human()})', color='green')
+    return f'{index_tag} {name_tag} {memory_tag}'
+
+
 def main() -> None:
     """Print a colored one-shot status summary for every CUDA-visible device."""
-    print(colored(time.strftime('%a %b %d %H:%M:%S %Y'), color='red', attrs=('bold',)))
+    print(
+        colored(time.strftime('%a %b %d %H:%M:%S %Y'), color='cyan', attrs=('bold',))
+        + '  '
+        + colored(f'{host.getuser()}@{host.hostname()}', color='white', attrs=('bold',)),
+    )
+    print(host_summary())
 
     devices = CudaDevice.all()  # or `Device.all()` to use NVML ordinal instead
-    separator = False
     for device in devices:
         # Batch all NVML queries for this device into a single round-trip
         with device.oneshot():
             processes = device.processes()
 
-            print(colored(str(device), color='green', attrs=('bold',)))
-            print(label('  - Fan speed:       ') + f'{device.fan_speed()}%')
-            print(label('  - Temperature:     ') + f'{device.temperature()}C')
-            print(label('  - GPU utilization: ') + f'{device.gpu_utilization()}%')
-            print(label('  - Total memory:    ') + f'{device.memory_total_human()}')
-            print(label('  - Used memory:     ') + f'{device.memory_used_human()}')
-            print(label('  - Free memory:     ') + f'{device.memory_free_human()}')
+            print(device_header(device))
+            memory_percent = device.memory_percent()
+            memory_used = device.memory_used_human()
+            memory_free = device.memory_free_human()
+            if memory_percent is not NA:
+                memory_used = f'{memory_used} ({memory_percent:.1f}%)'
+                memory_free = f'{memory_free} ({100.0 - memory_percent:.1f}%)'
+            for left, right in (
+                (
+                    field('Used Memory', memory_used, width=19, pad=18),
+                    field('Free Memory', memory_free, width=15),
+                ),
+                (
+                    field('GPU Utilization', device.gpu_utilization(), '%', width=19, pad=18),
+                    field('SM Clock', device.sm_clock(), 'MHz', width=15),
+                ),
+                (
+                    field('Memory Bandwidth', device.memory_utilization(), '%', width=19, pad=18),
+                    field('Memory Clock', device.memory_clock(), 'MHz', width=15),
+                ),
+                (
+                    field('Fan Speed', device.fan_speed(), '%', width=19, pad=18),
+                    field('Temperature', device.temperature(), 'C', width=15),
+                ),
+            ):
+                print(f'  {left}{right}'.rstrip())
         if len(processes) > 0:
             proc_snapshots = GpuProcess.take_snapshots(processes.values(), failsafe=True)
             proc_snapshots.sort(key=lambda process: (process.username, process.pid))
 
             print(label(f'  - Processes ({len(proc_snapshots)}):'))
             fmt = (
-                '    {pid:<5}  {username:<8} {cpu:>5}  {host_memory:>8} {time:>8}'
-                '  {gpu_memory:>8}  {sm:>3}  {command:<}'
+                '    {pid:<7}  {username:<8} {cpu:>5}  {host_memory:>8} {time:>8}'
+                '  {gpu_memory:>8}  {sm:>3}  {gmbw:>5}  {command:<}'
             ).format
             print(
                 colored(
@@ -65,6 +141,7 @@ def main() -> None:
                         time='TIME',
                         gpu_memory='GPU-MEM',
                         sm='SM%',
+                        gmbw='GMBW%',
                         command='COMMAND',
                     ),
                     attrs=('bold',),
@@ -78,7 +155,7 @@ def main() -> None:
                             snapshot.username[:7]
                             + ('+' if len(snapshot.username) > 8 else snapshot.username[7:8])
                         ),
-                        cpu=snapshot.cpu_percent,
+                        cpu=cpu_percent_text(snapshot.cpu_percent),
                         host_memory=snapshot.host_memory_human,
                         time=snapshot.running_time_human,
                         gpu_memory=(
@@ -87,15 +164,12 @@ def main() -> None:
                             else 'WDDM:N/A'
                         ),
                         sm=snapshot.gpu_sm_utilization,
+                        gmbw=snapshot.gpu_memory_utilization,
                         command=snapshot.command,
                     ),
                 )
         else:
             print(colored('  - No Running Processes', attrs=('bold',)))
-
-        if separator:
-            print('-' * 120)
-        separator = True
 
 
 if __name__ == '__main__':

--- a/examples/monitor-colored/monitor_colored.py
+++ b/examples/monitor-colored/monitor_colored.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""One-shot GPU monitor with ANSI color, using the CUDA ordinal."""
+"""One-shot GPU monitor with ANSI color, using the CUDA ordinal.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-colored/monitor_colored.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/monitor-minimal/README.md
+++ b/examples/monitor-minimal/README.md
@@ -14,6 +14,12 @@ A one-shot, no-extras script that prints the same information `nvitop` shows in 
 python3 examples/monitor-minimal/monitor_minimal.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-minimal/monitor_minimal.py
+```
+
 Requires only `nvitop` itself; no other dependencies.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/monitor-minimal/monitor_minimal.py
+++ b/examples/monitor-minimal/monitor_minimal.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Minimal one-shot GPU monitor: prints status + processes for every device."""
+"""Minimal one-shot GPU monitor: prints status + processes for every device.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-minimal/monitor_minimal.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/monitor-minimal/monitor_minimal.py
+++ b/examples/monitor-minimal/monitor_minimal.py
@@ -31,12 +31,11 @@ def main() -> None:
             sorted_pids = sorted(processes.keys())
 
             print(device)
-            print(f'  - Fan speed:       {device.fan_speed()}%')
+            print(f'  - Fan Speed:       {device.fan_speed()}%')
             print(f'  - Temperature:     {device.temperature()}C')
-            print(f'  - GPU utilization: {device.gpu_utilization()}%')
-            print(f'  - Total memory:    {device.memory_total_human()}')
-            print(f'  - Used memory:     {device.memory_used_human()}')
-            print(f'  - Free memory:     {device.memory_free_human()}')
+            print(f'  - GPU Utilization: {device.gpu_utilization()}%')
+            print(f'  - Used Memory:     {device.memory_used_human()}')
+            print(f'  - Free Memory:     {device.memory_free_human()}')
             print(f'  - Processes ({len(processes)}): {sorted_pids}')
             for pid in sorted_pids:
                 print(f'    - {processes[pid]}')

--- a/examples/monitor-web/README.md
+++ b/examples/monitor-web/README.md
@@ -33,6 +33,12 @@ Process snapshots are disabled with `root_pids={}` so the dashboard tracks host 
 python3 examples/monitor-web/monitor_web.py --port 5555
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-web/monitor_web.py --port 5555
+```
+
 Open <http://127.0.0.1:5555/> in a browser.
 
 The backend collector samples every `--interval` seconds, defaulting to `1.0`. The frontend polls `/metrics.json` every second and marks the dashboard stale if the latest sample is too old.

--- a/examples/monitor-web/monitor_web.py
+++ b/examples/monitor-web/monitor_web.py
@@ -20,7 +20,16 @@ Drives :func:`nvitop.collect_in_background` on a daemon thread, stores the sampl
 ring buffer (24h by default), and serves a small browser dashboard plus JSON endpoints
 (``/metrics.json``, ``/history.json``) over either HTTP or HTTPS using only the Python standard
 library.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/monitor-web/monitor_web.py --port 5555
 """
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/select-devices-api/README.md
+++ b/examples/select-devices-api/README.md
@@ -12,6 +12,12 @@ Shows [`nvitop.select_devices`][select-devices] — the Python API behind the [`
 python3 examples/select-devices-api/select_devices_api.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/select-devices-api/select_devices_api.py
+```
+
 Requires only `nvitop` itself; no other dependencies.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/select-devices-api/select_devices_api.py
+++ b/examples/select-devices-api/select_devices_api.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Use `nvitop.select_devices` to programmatically pick CUDA devices for a job."""
+"""Use `nvitop.select_devices` to programmatically pick CUDA devices for a job.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/select-devices-api/select_devices_api.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 

--- a/examples/take-snapshots/README.md
+++ b/examples/take-snapshots/README.md
@@ -14,6 +14,12 @@ Exercises every form of [`nvitop.take_snapshots`][take-snapshots] — the helper
 python3 examples/take-snapshots/take_snapshots_demo.py
 ```
 
+Or run it without cloning the repository, using [uv](https://docs.astral.sh/uv):
+
+```bash
+uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/take-snapshots/take_snapshots_demo.py
+```
+
 Requires only `nvitop` itself; no other dependencies.
 
 See [`../README.md`](../README.md) for the full example index.

--- a/examples/take-snapshots/take_snapshots_demo.py
+++ b/examples/take-snapshots/take_snapshots_demo.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Demonstrate `nvitop.take_snapshots` across NVML and CUDA enumerations."""
+"""Demonstrate `nvitop.take_snapshots` across NVML and CUDA enumerations.
+
+Run without cloning the repository using ``uv``::
+
+    uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/take-snapshots/take_snapshots_demo.py
+"""
+
+# /// script
+# requires-python = ">= 3.8"
+# dependencies = ["nvitop"]
+# ///
 
 from __future__ import annotations
 


### PR DESCRIPTION
#### Issue Type

- Bug fix
- Improvement/feature implementation

#### Runtime Environment

Examples and tooling change; validated in these environments:

- Operating system and version: Ubuntu (4× NVIDIA H100 80GB HBM3); macOS for lint / format
- Python version: `3.12.3`
- `nvitop` version or commit: `feat/examples-improvements` (this branch)
- Locale: `en_US.UTF-8`

#### Description

Two improvements to `examples/`, split into two commits.

**Enrich the colored monitor** (`monitor-colored`):

- Host summary line (`[Host]`: CPU / memory / swap / load) via `nvitop.host`.
- Two-column device panel with memory-usage percentages.
- White device name against green `[CUDA/NVML]` and total-memory tags.
- Wider PID column for 7-digit PIDs; CPU% now handles multi-threaded processes (>100%).
- Per-process GPU memory-bandwidth (`GMBW%`) column.
- Title-case the labels in `monitor-minimal` and drop its redundant total-memory line.

**Run scripts via `uv` from a URL, no clone** (all runnable examples):

- Add PEP 723 inline metadata (`requires-python` + `dependencies`) to the 8 runnable examples, so each runs straight from its URL:

  ```text
  uv run https://github.com/XuehaiPan/nvitop/raw/HEAD/examples/<dir>/<script>.py
  ```

- Each script's docstring and README now shows the `uv run` invocation. For the collector examples this replaces the `pip install -r requirements.txt` + `python3 …` steps with a single command.
- `ml-framework-callbacks` are `Callback` classes with no entry point, so they are left untouched.
- Add `uv` and `tensorboard` to the spelling wordlist.

#### Motivation and Context

Closes #221 — the `monitor-colored` example now surfaces `SM Clock` and `Memory Clock` on dedicated rows that are never truncated, providing the always-visible clock readout that issue asked for. The `nvitop` TUI's width-based truncation is intentional and left unchanged; this gives users a clock-visible alternative.

`uv run` support lets anyone try an example with a single command and zero setup — no clone, and no manual `pip install` for the examples that need extra dependencies.

#### Testing

- `pre-commit` passes on all changed files (ruff, ruff-format, mypy, pylint, codespell).
- All 8 runnable scripts pass `python3 -m py_compile`.
- `monitor-colored` rendered against mock devices (H100 + GB10 with `N/A` fields, 7-digit PIDs, >100% CPU) and on a real 4×H100 host.
- No runtime code outside `examples/` changed (plus two spelling-wordlist entries).
