### PR TITLE
fix(api/libnvml): probe the real running-process struct stride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix garbage PIDs (e.g. `psutil.NoSuchProcess: process PID out of range`) when the NVIDIA driver fills a smaller `nvmlProcessInfo_t` struct than the symbol-presence heuristic assumes, by measuring the real entry stride returned by `nvmlDeviceGet{Compute,Graphics,MPSCompute}RunningProcesses`.
 
 ### Removed
 

--- a/nvitop/api/libnvml.py
+++ b/nvitop/api/libnvml.py
@@ -775,6 +775,69 @@ if not _pynvml_installation_corrupted:
 
         return __get_running_processes_version_suffix
 
+    __process_info_struct_probed: bool = False
+
+    def __probe_process_info_struct(fn: _Any, handle: c_nvmlDevice_t) -> None:
+        """Measure the struct layout that the NVIDIA driver actually writes.
+
+        The symbol-presence heuristic in
+        :func:`__determine_get_running_processes_version_suffix` can select a struct that is
+        larger than the one the driver really fills in. For example, the R550 driver fills v1
+        type structs from ``nvmlDeviceGetComputeRunningProcesses_v3``, while the heuristic
+        selects the v2 type struct. Parsing a 16-byte-strided result with a 24-byte struct
+        silently shifts every entry after the first one and yields garbage PIDs, which crashes
+        the caller with ``psutil.NoSuchProcess: process PID out of range``.
+
+        Fill the output buffer with a sentinel byte and measure how much of it the driver
+        overwrites. ``written // count`` is the true entry stride.
+        """
+        global c_nvmlProcessInfo_t, __process_info_struct_probed  # pylint: disable=global-statement
+
+        sentinel = 0xAA
+        candidates = (c_nvmlProcessInfo_v1_t, c_nvmlProcessInfo_v2_t, c_nvmlProcessInfo_v3_t)
+
+        c_count = _ctypes.c_uint(0)
+        if fn(handle, _ctypes.byref(c_count), None) != NVML_ERROR_INSUFFICIENT_SIZE:
+            # No running processes on this device, nothing to measure. Retry on the next call.
+            return
+
+        count = c_count.value
+        buffer = (_ctypes.c_ubyte * (count * max(map(_ctypes.sizeof, candidates))))()
+        _ctypes.memset(buffer, sentinel, len(buffer))
+        c_count = _ctypes.c_uint(count)
+        if fn(handle, _ctypes.byref(c_count), _ctypes.byref(buffer)) != NVML_SUCCESS:
+            return
+        if c_count.value != count:
+            # The process list changed under us, the measurement would be meaningless.
+            return
+
+        __process_info_struct_probed = True
+        written = 0
+        for offset, byte in enumerate(buffer):
+            if byte != sentinel:
+                written = offset + 1
+        stride, remainder = divmod(written, count)
+        if remainder == 0:
+            for struct_type in candidates:
+                if _ctypes.sizeof(struct_type) == stride:
+                    if struct_type is not c_nvmlProcessInfo_t:
+                        LOGGER.debug(
+                            'NVML writes %d bytes per running process entry. Switch from struct '
+                            '%s to %s.',
+                            stride,
+                            c_nvmlProcessInfo_t.__name__,
+                            struct_type.__name__,
+                        )
+                    c_nvmlProcessInfo_t = struct_type
+                    return
+        LOGGER.debug(
+            'Cannot determine the NVML running process entry stride (%d bytes written for %d '
+            'entries). Keep using struct %s.',
+            written,
+            count,
+            c_nvmlProcessInfo_t.__name__,
+        )
+
     def __nvml_device_get_running_processes(
         func: str,
         /,
@@ -790,6 +853,8 @@ if not _pynvml_installation_corrupted:
         # First call to get the size
         c_count = _ctypes.c_uint(0)
         fn = _nvmlGetFunctionPointer(f'{func}{version_suffix}')
+        if not __process_info_struct_probed:
+            __probe_process_info_struct(fn, handle)
         ret = fn(handle, _ctypes.byref(c_count), None)
 
         if ret == NVML_SUCCESS:


### PR DESCRIPTION
Probe the real NVML running-process struct stride instead of inferring it from exported symbols

#### Issue Type

- Bug fix

#### Runtime Environment

- Operating system and version: Ubuntu 24.04.2 LTS (kernel 5.15.0-124-generic, inside a container)
- Terminal emulator and version: SSH session, no local emulator involved
- Python version: `3.12.3`
- NVML version (driver version): `12.550.127.08` (`550.127.08`), 8x NVIDIA Hopper, MIG disabled
- `nvitop` version or commit: `main@d6ad8da`
- `python-ml-py` version: `13.595.45`
- Locale: `LANG` unset, `locale.getpreferredencoding()` returns `UTF-8`

#### Description

`__determine_get_running_processes_version_suffix()` decides which `nvmlProcessInfo_t`
layout to parse by looking at which NVML symbols the driver exports. This PR keeps that
heuristic as the initial guess but verifies it against the driver at runtime.

Before the first `nvmlDeviceGet{Compute,Graphics,MPSCompute}RunningProcesses` query,
`__probe_process_info_struct()` fills the output buffer with a sentinel byte (`0xAA`), issues
the query, and scans how many bytes the driver overwrote. `written // count` is the true
per-entry stride, and the struct whose `ctypes.sizeof()` matches it is selected.

The probe is conservative:

- It runs at most once, and only until it gets a usable measurement (a device with no running
  processes yields nothing to measure, so it retries on the next query).
- If the returned count changes between the sizing call and the data call, the measurement is
  discarded.
- If the measured stride does not divide evenly or matches none of the three known structs,
  the heuristic's choice is kept unchanged.

So on drivers where the current detection is already correct, the probe measures the same
layout it would have picked and behaviour is identical. No existing line is modified; the
change is purely additive.

#### Motivation and Context

On R550 (`550.xxx.xx`) the driver exports both `nvmlDeviceGetConfComputeMemSizeInfo` and
`nvmlDeviceGetRunningProcessDetailList`, so the heuristic falls into the `else` branch of
`libnvml.py:746-751` and settles on the `_v3` API with the **v2 type struct (24 bytes)**.
That driver's `nvmlDeviceGetComputeRunningProcesses_v3` actually fills **v1 type structs
(16 bytes)** — a combination the current decision tree cannot express at all.

With an 8-byte stride mismatch, only the first entry parses correctly and everything after it
is read from the wrong offset. `Device.processes()` then hands a bogus PID to `HostProcess`:

    File "nvitop/api/device.py", line 2334, in processes
      proc = processes[p.pid] = self.GPU_PROCESS_CLASS(
    ...
    psutil.NoSuchProcess: process PID out of range (pid=xxxxxxxxxx)

Note that in-range-but-nonexistent PIDs are already tolerated (psutil's `_init(..., _ignore_nsp=True)`
renders them as `No Such Process`); only structurally invalid PIDs are fatal, which is why the
symptom is a hard crash rather than a cosmetic glitch.

#### Testing

Sentinel probe measurements on this machine (8 GPUs, 3 compute processes each):

```
_v2 → 3 entries,  72 bytes written → stride 24 → c_nvmlProcessInfo_v2_t
_v3 → 3 entries,  48 bytes written → stride 16 → c_nvmlProcessInfo_v1_t
```

Both are consistent across all 8 devices and across repeated runs.

Before, on `main@d6ad8da`:

```
$ python -m nvitop -1
psutil.NoSuchProcess: process PID out of range (pid=2782920704)
```

After:

```
$ NVITOP_LOGLEVEL=DEBUG python -m nvitop -1
[DEBUG] nvitop.api.libnvml::__probe_process_info_struct: NVML writes 16 bytes per running
process entry. Switch from struct c_nvmlProcessInfo_v2_t to c_nvmlProcessInfo_v1_t.
```

`Device.processes()` now returns PIDs and GPU memory that match `nvidia-smi` exactly on all
8 devices, and the TUI renders normally. Also exercised via `Device.all()` in the Python API
and via `nvitop -1` (`--once`).

Impact on other code paths: the only shared state touched is the module-level
`c_nvmlProcessInfo_t`, which is what `__nvml_device_get_running_processes()` already consumes.
`usedGpuCcProtectedMemory`, the only field present in the v3 struct but not the v2 struct, is
never read anywhere in the codebase, and `Device.processes()` already defaults
`gpuInstanceId` / `computeInstanceId` to `UINT_MAX` via `getattr()` when the selected struct
lacks them. Cost is one extra pair of NVML calls plus one buffer scan, once per process.

I do not have a MIG-enabled or a Confidential Computing machine to test on. On such systems
the driver writes the wider entries, the probe measures 24 or 32 bytes, and the selected
struct is the same one the current code picks — but a second pair of eyes there would be
welcome.

